### PR TITLE
Add detail page memory and fix back button navigation

### DIFF
--- a/app/(dashboard)/bookings/[id]/page.tsx
+++ b/app/(dashboard)/bookings/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   useCheckOutBooking,
   useDeleteBooking,
 } from '@/hooks/useBookings';
+import { useDetailPageMemory } from '@/hooks/useDetailPageMemory';
 import { formatBookingDates } from '@/utils/bookingUtils';
 import { Button } from '@heroui/button';
 import { Spinner } from '@heroui/spinner';
@@ -23,6 +24,7 @@ export default function BookingDetailsPage() {
   const params = useParams();
   const router = useRouter();
   const bookingId = params.id?.toString();
+  useDetailPageMemory('bookings');
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   // Booking mutations
@@ -151,7 +153,7 @@ export default function BookingDetailsPage() {
     <div className='container mx-auto px-4 py-6 max-w-6xl'>
       <BookingDetailsHeader
         booking={booking}
-        onBack={() => router.back()}
+        onBack={() => router.push('/bookings')}
         onBookingUpdated={() => mutate()}
         onDeleteSuccess={handleDeleteSuccess}
         deleteMutation={deleteMutation}

--- a/app/(dashboard)/bookings/page.tsx
+++ b/app/(dashboard)/bookings/page.tsx
@@ -10,6 +10,7 @@ import {
   useDeleteBooking,
   useUpdateBooking,
 } from '@/hooks/useBookings';
+import { clearDetailMemory } from '@/hooks/useDetailPageMemory';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { useURLFilters, bookingsFilterConfig } from '@/hooks/useURLFilters';
 import type {
@@ -49,6 +50,9 @@ function BookingsContent() {
   const updateBooking = useUpdateBooking();
   const deleteBooking = useDeleteBooking();
   const { showConfirm, ConfirmDialog } = useConfirmDialog();
+
+  // Clear detail page memory when landing on the list page
+  useEffect(() => { clearDetailMemory('bookings'); }, []);
 
   // Check for success message in URL (when coming back from new booking page)
   useEffect(() => {

--- a/app/(dashboard)/guests/[id]/page.tsx
+++ b/app/(dashboard)/guests/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
   useLockCustomer,
   useUnlockCustomer,
 } from '@/hooks/useCustomers';
+import { useDetailPageMemory } from '@/hooks/useDetailPageMemory';
 import {
   getInitials,
   getLoyaltyTier,
@@ -37,6 +38,7 @@ export default function GuestDetailPage() {
   const router = useRouter();
   const params = useParams();
   const customerId = params.id as string;
+  useDetailPageMemory('guests');
   const { data: customer, isLoading, error, mutate } = useCustomer(customerId);
   const deleteCustomerMutation = useDeleteCustomer();
   const lockCustomerMutation = useLockCustomer();
@@ -113,7 +115,7 @@ export default function GuestDetailPage() {
           <Button
             className='mt-2'
             variant='light'
-            onPress={() => router.back()}
+            onPress={() => router.push('/guests')}
           >
             Go Back
           </Button>
@@ -130,7 +132,7 @@ export default function GuestDetailPage() {
           <Button
             className='mt-2'
             variant='light'
-            onPress={() => router.back()}
+            onPress={() => router.push('/guests')}
           >
             Go Back
           </Button>
@@ -146,7 +148,7 @@ export default function GuestDetailPage() {
       {/* Header */}
       <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6'>
         <div className='flex items-center gap-4'>
-          <Button isIconOnly variant='light' onPress={() => router.back()}>
+          <Button isIconOnly variant='light' onPress={() => router.push('/guests')}>
             <ArrowLeftIcon />
           </Button>
           <div>

--- a/app/(dashboard)/guests/page.tsx
+++ b/app/(dashboard)/guests/page.tsx
@@ -4,6 +4,7 @@ import GuestGrid from '@/components/GuestGrid';
 import { PlusIcon } from '@/components/icons';
 import StandardFilters, { FilterOption } from '@/components/StandardFilters';
 import { useCustomers } from '@/hooks/useCustomers';
+import { clearDetailMemory } from '@/hooks/useDetailPageMemory';
 import { useURLFilters, guestsFilterConfig } from '@/hooks/useURLFilters';
 import type { CustomersFilters } from '@/types';
 import { Button } from '@heroui/button';
@@ -43,6 +44,9 @@ function GuestsContent() {
     if (!user?.id || !customers) return customers;
     return customers.filter(customer => customer.id !== user.id);
   }, [customers, user?.id]);
+
+  // Clear detail page memory when landing on the list page
+  useEffect(() => { clearDetailMemory('guests'); }, []);
 
   // Check for success message in URL (when coming back from new guest page)
   useEffect(() => {

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -17,6 +17,7 @@ import {
 } from '@heroui/navbar';
 
 import { ThemeSwitch } from '@/components/theme-switch';
+import { getDetailMemory } from '@/hooks/useDetailPageMemory';
 import { Button } from '@heroui/button';
 import clsx from 'clsx';
 import { useTheme } from 'next-themes';
@@ -33,6 +34,11 @@ import {
   Users,
   Settings,
 } from 'lucide-react';
+
+const MEMORY_SECTIONS: Record<string, string> = {
+  '/guests': 'guests',
+  '/bookings': 'bookings',
+};
 
 export const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -95,6 +101,9 @@ export const Navbar = () => {
 
       <NavbarMenu>
         {menuItems.map((item, index) => {
+          const sectionKey = MEMORY_SECTIONS[item.href];
+          const savedPath = sectionKey ? getDetailMemory(sectionKey) : null;
+          const effectiveHref = savedPath && savedPath.startsWith(item.href + '/') ? savedPath : item.href;
           const isLinkActive = pathName === item.href;
           const Icon = item.icon;
           return (
@@ -106,7 +115,7 @@ export const Navbar = () => {
                   'w-full p-2 flex items-center gap-3',
                   isLinkActive && 'font-bold rounded-lg bg-primary'
                 )}
-                href={item.href}
+                href={effectiveHref}
                 size='lg'
               >
                 <Icon size={20} />

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -3,8 +3,10 @@
 import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+
+import { getDetailMemory } from '@/hooks/useDetailPageMemory';
 
 const sidebarItems = [
   {
@@ -44,8 +46,14 @@ const sidebarItems = [
   },
 ];
 
+const MEMORY_SECTIONS: Record<string, string> = {
+  '/guests': 'guests',
+  '/bookings': 'bookings',
+};
+
 export const Sidebar = () => {
   const pathname = usePathname();
+  const router = useRouter();
   // const { resolvedTheme } = useTheme();
   const [_mounted, setMounted] = useState(false);
 
@@ -79,6 +87,16 @@ export const Sidebar = () => {
               <li key={item.href}>
                 <Link
                   href={item.href}
+                  onClick={(e) => {
+                    const sectionKey = MEMORY_SECTIONS[item.href];
+                    if (sectionKey) {
+                      const savedPath = getDetailMemory(sectionKey);
+                      if (savedPath && savedPath.startsWith(item.href + '/')) {
+                        e.preventDefault();
+                        router.push(savedPath);
+                      }
+                    }
+                  }}
                   className={clsx(
                     'flex items-center gap-3 px-3 py-2 rounded-lg transition-colors w-full text-left',
                     isActive

--- a/hooks/useDetailPageMemory.ts
+++ b/hooks/useDetailPageMemory.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+const STORAGE_PREFIX = 'detailMemory:';
+
+export function useDetailPageMemory(sectionKey: string): void {
+  useEffect(() => {
+    sessionStorage.setItem(
+      `${STORAGE_PREFIX}${sectionKey}`,
+      window.location.pathname
+    );
+  }, [sectionKey]);
+}
+
+export function clearDetailMemory(sectionKey: string): void {
+  sessionStorage.removeItem(`${STORAGE_PREFIX}${sectionKey}`);
+}
+
+export function getDetailMemory(sectionKey: string): string | null {
+  if (typeof window === 'undefined') return null;
+  return sessionStorage.getItem(`${STORAGE_PREFIX}${sectionKey}`);
+}


### PR DESCRIPTION
## Summary
- Adds `useDetailPageMemory` hook that saves the last-viewed detail page path in `sessionStorage`
- Sidebar and navbar restore the saved detail page when clicking Guests/Bookings links
- Back buttons on detail pages use explicit `router.push('/guests')` / `router.push('/bookings')` instead of `router.back()`, which was unreliable when sidebar redirects polluted the browser history stack
- Saved paths are validated with `startsWith(item.href + '/')` to ensure only sub-routes of the correct section are used for redirects

## Test plan
- [ ] Navigate: Guests list → guest detail → Dining → click "Guests" in sidebar → should return to the same guest detail page
- [ ] From guest detail, click back arrow → should land on `/guests` list (not previous history entry)
- [ ] Same flow for Bookings section
- [ ] Direct navigation to a detail page URL → back arrow → should go to list page
- [ ] Error/not-found states on detail pages → "Go Back" button → should go to list page
- [ ] Navigate to guest detail → go to list page → sidebar memory should be cleared → clicking "Guests" again goes to list
- [ ] Mobile navbar links follow the same memory behavior