### PR TITLE
Fix guest page loading skeleton mismatch

### DIFF
--- a/app/(dashboard)/guests/page.tsx
+++ b/app/(dashboard)/guests/page.tsx
@@ -180,13 +180,36 @@ export default function GuestsPage() {
               Add New Guest
             </Button>
           </div>
-          <Card>
-            <CardBody>
-              <div className='flex justify-center items-center py-8'>
-                <div className='text-default-500'>Loading...</div>
-              </div>
-            </CardBody>
-          </Card>
+          <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 mb-6'>
+            {[...Array(12)].map((_, i) => (
+              <Card key={i}>
+                <CardBody className='p-4'>
+                  <div className='flex items-start gap-3'>
+                    <div className='w-10 h-10 bg-default-200 rounded-full animate-pulse flex-shrink-0' />
+                    <div className='flex-1 min-w-0'>
+                      <div className='h-4 bg-default-200 rounded animate-pulse' />
+                      <div className='h-3 bg-default-200 rounded w-2/3 animate-pulse mt-1.5' />
+                      <div className='h-3 bg-default-200 rounded w-1/2 animate-pulse mt-1.5' />
+                    </div>
+                  </div>
+                  <div className='mt-4 space-y-2'>
+                    <div className='flex justify-between items-center'>
+                      <div className='h-3 bg-default-200 rounded w-16 animate-pulse' />
+                      <div className='h-3 bg-default-200 rounded w-8 animate-pulse' />
+                    </div>
+                    <div className='flex justify-between items-center'>
+                      <div className='h-3 bg-default-200 rounded w-12 animate-pulse' />
+                      <div className='h-3 bg-default-200 rounded w-14 animate-pulse' />
+                    </div>
+                    <div className='flex justify-between items-center'>
+                      <div className='h-3 bg-default-200 rounded w-14 animate-pulse' />
+                      <div className='h-5 bg-default-200 rounded-full w-16 animate-pulse' />
+                    </div>
+                  </div>
+                </CardBody>
+              </Card>
+            ))}
+          </div>
         </div>
       }
     >

--- a/components/GuestGrid.tsx
+++ b/components/GuestGrid.tsx
@@ -23,15 +23,30 @@ export default function GuestGrid({
   // Loading State
   if (isLoading) {
     return (
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4'>
-        {[...Array(8)].map((_, i) => (
-          <Card key={i} className='p-4'>
-            <CardBody className='space-y-3'>
-              <div className='flex items-center gap-3'>
-                <div className='w-12 h-12 bg-default-200 rounded-full animate-pulse' />
-                <div className='space-y-2 flex-1'>
+      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 mb-6'>
+        {[...Array(12)].map((_, i) => (
+          <Card key={i}>
+            <CardBody className='p-4'>
+              <div className='flex items-start gap-3'>
+                <div className='w-10 h-10 bg-default-200 rounded-full animate-pulse flex-shrink-0' />
+                <div className='flex-1 min-w-0'>
                   <div className='h-4 bg-default-200 rounded animate-pulse' />
-                  <div className='h-3 bg-default-200 rounded w-2/3 animate-pulse' />
+                  <div className='h-3 bg-default-200 rounded w-2/3 animate-pulse mt-1.5' />
+                  <div className='h-3 bg-default-200 rounded w-1/2 animate-pulse mt-1.5' />
+                </div>
+              </div>
+              <div className='mt-4 space-y-2'>
+                <div className='flex justify-between items-center'>
+                  <div className='h-3 bg-default-200 rounded w-16 animate-pulse' />
+                  <div className='h-3 bg-default-200 rounded w-8 animate-pulse' />
+                </div>
+                <div className='flex justify-between items-center'>
+                  <div className='h-3 bg-default-200 rounded w-12 animate-pulse' />
+                  <div className='h-3 bg-default-200 rounded w-14 animate-pulse' />
+                </div>
+                <div className='flex justify-between items-center'>
+                  <div className='h-3 bg-default-200 rounded w-14 animate-pulse' />
+                  <div className='h-5 bg-default-200 rounded-full w-16 animate-pulse' />
                 </div>
               </div>
             </CardBody>


### PR DESCRIPTION
## Summary
- Updated loading skeleton in `GuestGrid.tsx` and Suspense fallback in `guests/page.tsx` to match the actual `GuestCard` layout
- Added missing nationality line and stats block (Bookings/Spent/Status) placeholders to skeleton cards
- Changed skeleton card count from 8 to 12 to match `guestsFilterConfig.limit.defaultValue`
- Fixed card padding (`p-4` on `CardBody` instead of `Card`) and alignment (`items-start` instead of `items-center`)

## Test plan
- [x] Navigate to `/guests` and verify the initial Suspense skeleton matches card dimensions
- [x] Wait for data to load and confirm no layout shift occurs
- [x] Click to page 2+ and verify the pagination skeleton height matches the previously visible cards
- [x] Test across responsive breakpoints (mobile, tablet, desktop)