### PR TITLE
Add booking analytics dashboard

### DIFF
--- a/app/(dashboard)/bookings/analytics/page.tsx
+++ b/app/(dashboard)/bookings/analytics/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import BookingAnalyticsStats from '@/components/BookingAnalyticsStats';
+import GuestDemographics from '@/components/GuestDemographics';
+import PopularCabinsChart from '@/components/PopularCabinsChart';
+import RevenueOverTimeChart from '@/components/RevenueOverTimeChart';
+import StatusDistributionChart from '@/components/StatusDistributionChart';
+import {
+  useBookingAnalytics,
+  type AnalyticsPeriod,
+  type BookingAnalyticsData,
+} from '@/hooks/useBookingAnalytics';
+import { Button } from '@heroui/button';
+import { Tab, Tabs } from '@heroui/tabs';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+function generateCSV(data: BookingAnalyticsData, period: AnalyticsPeriod) {
+  const lines: string[] = [];
+
+  // Summary
+  lines.push('Section,Metric,Value');
+  lines.push(`Summary,Total Revenue,$${data.summary.totalRevenue}`);
+  lines.push(`Summary,Total Bookings,${data.summary.totalBookings}`);
+  lines.push(`Summary,Avg Booking Value,$${data.summary.avgBookingValue}`);
+  lines.push(`Summary,Cancellation Rate,${data.summary.cancellationRate}%`);
+  lines.push('');
+
+  // Revenue over time
+  lines.push('Date,Revenue,Bookings');
+  for (const row of data.revenueOverTime) {
+    lines.push(`${row.date},${row.revenue},${row.bookings}`);
+  }
+  lines.push('');
+
+  // Status distribution
+  lines.push('Status,Count');
+  for (const row of data.statusDistribution) {
+    lines.push(`${row.status},${row.count}`);
+  }
+  lines.push('');
+
+  // Popular cabins
+  lines.push('Cabin,Booking Count,Revenue');
+  for (const row of data.popularCabins) {
+    lines.push(`${row.name},${row.bookingCount},${row.revenue}`);
+  }
+  lines.push('');
+
+  // Demographics
+  lines.push('Demographic,Value');
+  lines.push(`Avg Party Size,${data.demographics.avgPartySize}`);
+  lines.push(`Avg Stay Length,${data.demographics.avgStayLength}`);
+  lines.push(`Breakfast Rate,${data.demographics.extras.breakfast.rate}%`);
+  lines.push(`Pet Rate,${data.demographics.extras.pets.rate}%`);
+  lines.push(`Parking Rate,${data.demographics.extras.parking.rate}%`);
+  lines.push(
+    `Early Check-in Rate,${data.demographics.extras.earlyCheckIn.rate}%`
+  );
+  lines.push(
+    `Late Check-out Rate,${data.demographics.extras.lateCheckOut.rate}%`
+  );
+
+  const csvContent = lines.join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  const dateStr = new Date().toISOString().split('T')[0];
+  link.href = url;
+  link.download = `booking-analytics-${period}-${dateStr}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+const PERIOD_OPTIONS: { key: AnalyticsPeriod; label: string }[] = [
+  { key: '7d', label: '7 Days' },
+  { key: '30d', label: '30 Days' },
+  { key: '90d', label: '90 Days' },
+  { key: '1y', label: '1 Year' },
+  { key: 'all', label: 'All Time' },
+];
+
+export default function BookingAnalyticsPage() {
+  const router = useRouter();
+  const [period, setPeriod] = useState<AnalyticsPeriod>('30d');
+  const { data, isLoading } = useBookingAnalytics(period);
+
+  return (
+    <div className='container mx-auto px-4 py-8'>
+      {/* Header */}
+      <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-8'>
+        <div>
+          <div className='flex items-center gap-3 mb-1'>
+            <button
+              onClick={() => router.push('/bookings')}
+              className='text-default-400 hover:text-default-600 transition-colors'
+              aria-label='Back to bookings'
+            >
+              <svg
+                width='20'
+                height='20'
+                viewBox='0 0 24 24'
+                fill='none'
+                stroke='currentColor'
+                strokeWidth='2'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              >
+                <path d='M19 12H5M12 19l-7-7 7-7' />
+              </svg>
+            </button>
+            <h1 className='text-3xl font-bold'>Booking Analytics</h1>
+          </div>
+          <p className='text-default-600 mt-1 ml-8'>
+            Insights into booking trends, revenue, and guest behavior
+          </p>
+        </div>
+        <Button
+          variant='bordered'
+          isDisabled={isLoading || !data}
+          onPress={() => data && generateCSV(data, period)}
+          className='w-full sm:w-auto'
+        >
+          Export CSV
+        </Button>
+      </div>
+
+      {/* Period Selector */}
+      <div className='mb-6'>
+        <Tabs
+          selectedKey={period}
+          onSelectionChange={key => setPeriod(key as AnalyticsPeriod)}
+          variant='bordered'
+          size='sm'
+        >
+          {PERIOD_OPTIONS.map(opt => (
+            <Tab key={opt.key} title={opt.label} />
+          ))}
+        </Tabs>
+      </div>
+
+      {/* Stats Cards */}
+      <div className='mb-6'>
+        <BookingAnalyticsStats
+          summary={data?.summary}
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Revenue Chart */}
+      <div className='mb-6'>
+        <RevenueOverTimeChart
+          data={data?.revenueOverTime}
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Two-column: Status Distribution + Popular Cabins */}
+      <div className='grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6'>
+        <StatusDistributionChart
+          data={data?.statusDistribution}
+          isLoading={isLoading}
+        />
+        <PopularCabinsChart
+          data={data?.popularCabins}
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Demographics */}
+      <GuestDemographics
+        demographics={data?.demographics}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/bookings/page.tsx
+++ b/app/(dashboard)/bookings/page.tsx
@@ -200,14 +200,23 @@ function BookingsContent() {
             Manage cabin reservations and guest check-ins
           </p>
         </div>
-        <Button
-          color='primary'
-          startContent={<PlusIcon />}
-          onPress={() => router.push('/bookings/new')}
-          className='w-full sm:w-auto'
-        >
-          New Booking
-        </Button>
+        <div className='flex gap-2 w-full sm:w-auto'>
+          <Button
+            variant='bordered'
+            onPress={() => router.push('/bookings/analytics')}
+            className='flex-1 sm:flex-none'
+          >
+            Analytics
+          </Button>
+          <Button
+            color='primary'
+            startContent={<PlusIcon />}
+            onPress={() => router.push('/bookings/new')}
+            className='flex-1 sm:flex-none'
+          >
+            New Booking
+          </Button>
+        </div>
       </div>
 
       {/* Filters */}

--- a/app/api/bookings/analytics/route.ts
+++ b/app/api/bookings/analytics/route.ts
@@ -1,0 +1,289 @@
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  HTTP_STATUS,
+  requireApiAuth,
+} from '@/lib/api-utils';
+import connectDB from '@/lib/mongodb';
+import { Booking } from '../../../../models';
+import { NextRequest } from 'next/server';
+
+type Period = '7d' | '30d' | '90d' | '1y' | 'all';
+
+function getPeriodDays(period: Period): number | null {
+  switch (period) {
+    case '7d':
+      return 7;
+    case '30d':
+      return 30;
+    case '90d':
+      return 90;
+    case '1y':
+      return 365;
+    case 'all':
+      return null;
+  }
+}
+
+function getGroupFormat(period: Period): 'daily' | 'weekly' {
+  return period === '7d' || period === '30d' ? 'daily' : 'weekly';
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await requireApiAuth();
+  if (!authResult.authenticated) return authResult.error;
+
+  try {
+    await connectDB();
+
+    const { searchParams } = new URL(request.url);
+    const period = (searchParams.get('period') || '30d') as Period;
+    const validPeriods: Period[] = ['7d', '30d', '90d', '1y', 'all'];
+    if (!validPeriods.includes(period)) {
+      return createErrorResponse('Invalid period', HTTP_STATUS.BAD_REQUEST);
+    }
+
+    const days = getPeriodDays(period);
+    const now = new Date();
+    const startDate = days
+      ? new Date(now.getTime() - days * 24 * 60 * 60 * 1000)
+      : null;
+
+    const dateFilter = startDate ? { createdAt: { $gte: startDate } } : {};
+
+    const [summaryResult, cancelledCount, revenueOverTime, statusDist, popularCabins] =
+      await Promise.all([
+        // 1. Summary stats (exclude cancelled)
+        Booking.aggregate([
+          {
+            $match: {
+              ...dateFilter,
+              status: { $ne: 'cancelled' },
+            },
+          },
+          {
+            $group: {
+              _id: null,
+              totalRevenue: {
+                $sum: { $cond: [{ $eq: ['$isPaid', true] }, '$totalPrice', 0] },
+              },
+              totalBookings: { $sum: 1 },
+              avgBookingValue: { $avg: '$totalPrice' },
+              avgNumGuests: { $avg: '$numGuests' },
+              avgNumNights: { $avg: '$numNights' },
+              breakfastCount: {
+                $sum: { $cond: ['$extras.hasBreakfast', 1, 0] },
+              },
+              petCount: { $sum: { $cond: ['$extras.hasPets', 1, 0] } },
+              parkingCount: {
+                $sum: { $cond: ['$extras.hasParking', 1, 0] },
+              },
+              earlyCheckInCount: {
+                $sum: { $cond: ['$extras.hasEarlyCheckIn', 1, 0] },
+              },
+              lateCheckOutCount: {
+                $sum: { $cond: ['$extras.hasLateCheckOut', 1, 0] },
+              },
+            },
+          },
+        ]),
+
+        // 2. Cancellation count
+        Booking.countDocuments({
+          ...dateFilter,
+          status: 'cancelled',
+        }),
+
+        // 3. Revenue over time
+        Booking.aggregate([
+          {
+            $match: {
+              ...dateFilter,
+              status: { $ne: 'cancelled' },
+            },
+          },
+          {
+            $group: {
+              _id:
+                getGroupFormat(period) === 'daily'
+                  ? {
+                      $dateToString: {
+                        format: '%Y-%m-%d',
+                        date: '$createdAt',
+                      },
+                    }
+                  : {
+                      $dateToString: {
+                        format: '%Y-%U',
+                        date: '$createdAt',
+                      },
+                    },
+              revenue: {
+                $sum: {
+                  $cond: [{ $eq: ['$isPaid', true] }, '$totalPrice', 0],
+                },
+              },
+              bookings: { $sum: 1 },
+            },
+          },
+          { $sort: { _id: 1 } },
+        ]),
+
+        // 4. Status distribution
+        Booking.aggregate([
+          { $match: dateFilter },
+          {
+            $group: {
+              _id: '$status',
+              count: { $sum: 1 },
+            },
+          },
+        ]),
+
+        // 5. Popular cabins
+        Booking.aggregate([
+          {
+            $match: {
+              ...dateFilter,
+              status: { $ne: 'cancelled' },
+            },
+          },
+          {
+            $group: {
+              _id: '$cabin',
+              bookingCount: { $sum: 1 },
+              revenue: { $sum: '$totalPrice' },
+            },
+          },
+          {
+            $lookup: {
+              from: 'cabins',
+              localField: '_id',
+              foreignField: '_id',
+              as: 'cabinInfo',
+            },
+          },
+          { $unwind: '$cabinInfo' },
+          {
+            $project: {
+              _id: 0,
+              name: '$cabinInfo.name',
+              bookingCount: 1,
+              revenue: { $round: ['$revenue', 0] },
+            },
+          },
+          { $sort: { bookingCount: -1 } },
+          { $limit: 10 },
+        ]),
+      ]);
+
+    const summary = summaryResult[0] || {
+      totalRevenue: 0,
+      totalBookings: 0,
+      avgBookingValue: 0,
+      avgNumGuests: 0,
+      avgNumNights: 0,
+      breakfastCount: 0,
+      petCount: 0,
+      parkingCount: 0,
+      earlyCheckInCount: 0,
+      lateCheckOutCount: 0,
+    };
+
+    const totalWithCancelled = summary.totalBookings + cancelledCount;
+    const cancellationRate =
+      totalWithCancelled > 0
+        ? Math.round((cancelledCount / totalWithCancelled) * 1000) / 10
+        : 0;
+
+    // Fill zero-gaps for revenue over time
+    const filledRevenue: { date: string; revenue: number; bookings: number }[] =
+      [];
+
+    if (getGroupFormat(period) === 'daily' && startDate) {
+      const totalDays = days!;
+      for (let i = totalDays - 1; i >= 0; i--) {
+        const date = new Date(now);
+        date.setDate(date.getDate() - i);
+        const dateString = date.toISOString().split('T')[0];
+        const dayData = revenueOverTime.find(
+          (item: { _id: string }) => item._id === dateString
+        );
+        filledRevenue.push({
+          date: date.toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+          }),
+          revenue: dayData?.revenue || 0,
+          bookings: dayData?.bookings || 0,
+        });
+      }
+    } else {
+      // For weekly grouping, just format the data as-is
+      for (const item of revenueOverTime) {
+        filledRevenue.push({
+          date: item._id,
+          revenue: item.revenue || 0,
+          bookings: item.bookings || 0,
+        });
+      }
+    }
+
+    const totalBookings = summary.totalBookings || 1; // Avoid division by zero
+
+    return createSuccessResponse({
+      summary: {
+        totalRevenue: Math.round(summary.totalRevenue),
+        totalBookings: summary.totalBookings,
+        avgBookingValue: Math.round(summary.avgBookingValue || 0),
+        cancellationRate,
+      },
+      revenueOverTime: filledRevenue,
+      statusDistribution: statusDist.map(
+        (item: { _id: string; count: number }) => ({
+          status: item._id,
+          count: item.count,
+        })
+      ),
+      popularCabins,
+      demographics: {
+        avgPartySize:
+          Math.round((summary.avgNumGuests || 0) * 10) / 10,
+        avgStayLength:
+          Math.round((summary.avgNumNights || 0) * 10) / 10,
+        extras: {
+          breakfast: {
+            count: summary.breakfastCount,
+            rate: Math.round((summary.breakfastCount / totalBookings) * 100),
+          },
+          pets: {
+            count: summary.petCount,
+            rate: Math.round((summary.petCount / totalBookings) * 100),
+          },
+          parking: {
+            count: summary.parkingCount,
+            rate: Math.round((summary.parkingCount / totalBookings) * 100),
+          },
+          earlyCheckIn: {
+            count: summary.earlyCheckInCount,
+            rate: Math.round(
+              (summary.earlyCheckInCount / totalBookings) * 100
+            ),
+          },
+          lateCheckOut: {
+            count: summary.lateCheckOutCount,
+            rate: Math.round(
+              (summary.lateCheckOutCount / totalBookings) * 100
+            ),
+          },
+        },
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching booking analytics:', error);
+    return createErrorResponse(
+      'Failed to fetch booking analytics',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
+    );
+  }
+}

--- a/components/BookingAnalyticsStats.tsx
+++ b/components/BookingAnalyticsStats.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import OverviewInfoCard from './OverviewInfoCard';
+
+interface Props {
+  summary?: {
+    totalRevenue: number;
+    totalBookings: number;
+    avgBookingValue: number;
+    cancellationRate: number;
+  };
+  isLoading: boolean;
+}
+
+export default function BookingAnalyticsStats({ summary, isLoading }: Props) {
+  if (isLoading) {
+    return (
+      <div className='grid grid-cols-2 lg:grid-cols-4 gap-4 w-full'>
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            className='bg-content1 p-4 rounded-lg border border-divider animate-pulse'
+          >
+            <div className='h-4 bg-default-200 rounded mb-2'></div>
+            <div className='h-6 bg-default-200 rounded'></div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!summary) return null;
+
+  return (
+    <div className='grid grid-cols-2 lg:grid-cols-4 gap-4 w-full'>
+      <OverviewInfoCard
+        title='Total Revenue'
+        description={`$${summary.totalRevenue.toLocaleString()}`}
+        variant='blue'
+      />
+      <OverviewInfoCard
+        title='Total Bookings'
+        description={summary.totalBookings.toString()}
+        variant='green'
+      />
+      <OverviewInfoCard
+        title='Avg Booking Value'
+        description={`$${summary.avgBookingValue.toLocaleString()}`}
+        variant='purple'
+      />
+      <OverviewInfoCard
+        title='Cancellation Rate'
+        description={`${summary.cancellationRate}%`}
+        variant='orange'
+      />
+    </div>
+  );
+}

--- a/components/GuestDemographics.tsx
+++ b/components/GuestDemographics.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+interface ExtrasStat {
+  count: number;
+  rate: number;
+}
+
+interface Props {
+  demographics?: {
+    avgPartySize: number;
+    avgStayLength: number;
+    extras: {
+      breakfast: ExtrasStat;
+      pets: ExtrasStat;
+      parking: ExtrasStat;
+      earlyCheckIn: ExtrasStat;
+      lateCheckOut: ExtrasStat;
+    };
+  };
+  isLoading: boolean;
+}
+
+function StatItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className='flex flex-col items-center p-3 rounded-lg bg-default-50 dark:bg-default-100/50'>
+      <span className='text-xs text-default-500 uppercase tracking-wide mb-1'>
+        {label}
+      </span>
+      <span className='text-lg font-bold'>{value}</span>
+    </div>
+  );
+}
+
+export default function GuestDemographics({ demographics, isLoading }: Props) {
+  if (isLoading) {
+    return (
+      <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+        <h3 className='text-lg md:text-xl font-bold mb-4'>
+          Guest Demographics
+        </h3>
+        <div className='grid grid-cols-2 md:grid-cols-3 gap-3'>
+          {[...Array(6)].map((_, i) => (
+            <div
+              key={i}
+              className='h-16 bg-default-100 rounded-lg animate-pulse'
+            ></div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!demographics) return null;
+
+  return (
+    <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+      <h3 className='text-lg md:text-xl font-bold mb-4'>Guest Demographics</h3>
+      <div className='grid grid-cols-2 md:grid-cols-3 gap-3'>
+        <StatItem
+          label='Avg Party Size'
+          value={`${demographics.avgPartySize} guests`}
+        />
+        <StatItem
+          label='Avg Stay Length'
+          value={`${demographics.avgStayLength} nights`}
+        />
+        <StatItem
+          label='Breakfast Adoption'
+          value={`${demographics.extras.breakfast.rate}%`}
+        />
+        <StatItem
+          label='Pet Bookings'
+          value={`${demographics.extras.pets.rate}%`}
+        />
+        <StatItem
+          label='Parking Add-on'
+          value={`${demographics.extras.parking.rate}%`}
+        />
+        <StatItem
+          label='Early/Late Check'
+          value={`${Math.max(demographics.extras.earlyCheckIn.rate, demographics.extras.lateCheckOut.rate)}%`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/PopularCabinsChart.tsx
+++ b/components/PopularCabinsChart.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface CabinItem {
+  name: string;
+  bookingCount: number;
+  revenue: number;
+}
+
+interface TooltipPayloadItem {
+  payload: CabinItem;
+  value: number;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}
+
+interface Props {
+  data?: CabinItem[];
+  isLoading: boolean;
+}
+
+export default function PopularCabinsChart({ data, isLoading }: Props) {
+  const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
+    if (active && payload && payload.length) {
+      const item = payload[0].payload;
+      return (
+        <div className='bg-content1 p-3 border border-divider rounded-lg shadow-lg'>
+          <p className='font-medium'>{item.name}</p>
+          <p className='text-sm text-default-600'>
+            {item.bookingCount} bookings
+          </p>
+          <p className='text-sm text-default-600'>
+            ${item.revenue.toLocaleString()} revenue
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (isLoading) {
+    return (
+      <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+        <h3 className='text-lg md:text-xl font-bold mb-4'>Popular Cabins</h3>
+        <div className='h-64 bg-default-100 rounded-lg animate-pulse'></div>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+        <h3 className='text-lg md:text-xl font-bold mb-4'>Popular Cabins</h3>
+        <div className='h-64 flex items-center justify-center text-default-400'>
+          No data available
+        </div>
+      </div>
+    );
+  }
+
+  const chartHeight = Math.max(data.length * 40, 200);
+
+  return (
+    <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+      <h3 className='text-lg md:text-xl font-bold mb-4'>Popular Cabins</h3>
+      <div style={{ height: Math.min(chartHeight, 320) }}>
+        <ResponsiveContainer width='100%' height='100%'>
+          <BarChart
+            data={data}
+            layout='vertical'
+            margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid
+              strokeDasharray='3 3'
+              stroke='#e5e7eb'
+              opacity={0.5}
+              horizontal={false}
+            />
+            <XAxis
+              type='number'
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: '#6b7280' }}
+            />
+            <YAxis
+              type='category'
+              dataKey='name'
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: '#6b7280' }}
+              width={100}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Bar
+              dataKey='bookingCount'
+              fill='#8b5cf6'
+              radius={[0, 4, 4, 0]}
+              barSize={20}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/components/RevenueOverTimeChart.tsx
+++ b/components/RevenueOverTimeChart.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import {
+  Area,
+  CartesianGrid,
+  AreaChart as RechartsAreaChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface TooltipPayloadItem {
+  dataKey: string;
+  color: string;
+  value: number;
+  name: string;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+  label?: string;
+}
+
+interface Props {
+  data?: { date: string; revenue: number; bookings: number }[];
+  isLoading: boolean;
+}
+
+export default function RevenueOverTimeChart({ data, isLoading }: Props) {
+  const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+    if (active && payload && payload.length) {
+      const revenueData = payload.find(p => p.dataKey === 'revenue');
+      const bookingsData = payload.find(p => p.dataKey === 'bookings');
+
+      return (
+        <div className='bg-content1 p-3 border border-divider rounded-lg shadow-lg'>
+          <p className='font-medium mb-2'>{label}</p>
+          <div className='space-y-1'>
+            {revenueData && (
+              <p className='text-sm'>
+                <span style={{ color: revenueData.color }}>● </span>
+                Revenue: ${revenueData.value.toLocaleString()}
+              </p>
+            )}
+            {bookingsData && (
+              <p className='text-sm'>
+                <span style={{ color: bookingsData.color }}>● </span>
+                Bookings: {bookingsData.value}
+              </p>
+            )}
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const formatYAxisRevenue = (value: number) => {
+    if (value >= 1000) return `$${(value / 1000).toFixed(0)}k`;
+    return `$${value}`;
+  };
+
+  if (isLoading) {
+    return (
+      <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+        <h3 className='text-lg md:text-xl font-bold mb-4'>Revenue Trend</h3>
+        <div className='h-64 md:h-80 bg-default-100 rounded-lg animate-pulse'></div>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+        <h3 className='text-lg md:text-xl font-bold mb-4'>Revenue Trend</h3>
+        <div className='h-64 md:h-80 flex items-center justify-center text-default-400'>
+          No data available for this period
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+      <h3 className='text-lg md:text-xl font-bold mb-4'>Revenue Trend</h3>
+      <div className='h-64 md:h-80'>
+        <ResponsiveContainer width='100%' height='100%'>
+          <RechartsAreaChart
+            data={data}
+            margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+          >
+            <defs>
+              <linearGradient
+                id='revenueGradient'
+                x1='0'
+                y1='0'
+                x2='0'
+                y2='1'
+              >
+                <stop offset='5%' stopColor='#3b82f6' stopOpacity={0.8} />
+                <stop offset='95%' stopColor='#3b82f6' stopOpacity={0.1} />
+              </linearGradient>
+              <linearGradient
+                id='analyticsBookingsGradient'
+                x1='0'
+                y1='0'
+                x2='0'
+                y2='1'
+              >
+                <stop offset='5%' stopColor='#10b981' stopOpacity={0.8} />
+                <stop offset='95%' stopColor='#10b981' stopOpacity={0.1} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid
+              strokeDasharray='3 3'
+              stroke='#e5e7eb'
+              opacity={0.5}
+            />
+            <XAxis
+              dataKey='date'
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 10, fill: '#6b7280' }}
+              interval='preserveStartEnd'
+            />
+            <YAxis
+              yAxisId='revenue'
+              orientation='left'
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 10, fill: '#6b7280' }}
+              tickFormatter={formatYAxisRevenue}
+              width={50}
+            />
+            <YAxis
+              yAxisId='bookings'
+              orientation='right'
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 10, fill: '#6b7280' }}
+              width={30}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Area
+              yAxisId='revenue'
+              type='monotone'
+              dataKey='revenue'
+              stroke='#3b82f6'
+              strokeWidth={2}
+              fillOpacity={1}
+              fill='url(#revenueGradient)'
+            />
+            <Area
+              yAxisId='bookings'
+              type='monotone'
+              dataKey='bookings'
+              stroke='#10b981'
+              strokeWidth={2}
+              fillOpacity={1}
+              fill='url(#analyticsBookingsGradient)'
+            />
+          </RechartsAreaChart>
+        </ResponsiveContainer>
+      </div>
+      <div className='flex flex-col sm:flex-row justify-center gap-4 sm:gap-6 mt-4'>
+        <div className='flex items-center gap-2'>
+          <div className='w-3 h-3 rounded-full bg-blue-500' />
+          <span className='text-sm font-medium'>Revenue ($)</span>
+        </div>
+        <div className='flex items-center gap-2'>
+          <div className='w-3 h-3 rounded-full bg-green-500' />
+          <span className='text-sm font-medium'>Bookings (#)</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/StatusDistributionChart.tsx
+++ b/components/StatusDistributionChart.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+
+interface StatusItem {
+  status: string;
+  count: number;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: { name: string; value: number }[];
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  confirmed: '#3b82f6',
+  'checked-in': '#10b981',
+  'checked-out': '#6b7280',
+  cancelled: '#ef4444',
+  unconfirmed: '#f59e0b',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  confirmed: 'Confirmed',
+  'checked-in': 'Checked In',
+  'checked-out': 'Checked Out',
+  cancelled: 'Cancelled',
+  unconfirmed: 'Unconfirmed',
+};
+
+interface Props {
+  data?: StatusItem[];
+  isLoading: boolean;
+}
+
+export default function StatusDistributionChart({ data, isLoading }: Props) {
+  const chartData = (data || []).map(item => ({
+    name: STATUS_LABELS[item.status] || item.status,
+    value: item.count,
+    color: STATUS_COLORS[item.status] || '#9ca3af',
+  }));
+
+  const sortedData = [...chartData].sort((a, b) => b.value - a.value);
+  const total = sortedData.reduce((sum, item) => sum + item.value, 0);
+
+  const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
+    if (active && payload && payload.length) {
+      const item = payload[0];
+      return (
+        <div className='bg-content1 p-3 border border-divider rounded-lg shadow-lg'>
+          <p className='font-medium'>{item.name}</p>
+          <p className='text-sm text-default-600'>
+            {item.value} bookings (
+            {total > 0 ? ((item.value / total) * 100).toFixed(1) : 0}%)
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (isLoading) {
+    return (
+      <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+        <h3 className='text-lg md:text-xl font-bold mb-4'>
+          Status Distribution
+        </h3>
+        <div className='h-64 bg-default-100 rounded-lg animate-pulse'></div>
+      </div>
+    );
+  }
+
+  if (!data || sortedData.length === 0) {
+    return (
+      <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+        <h3 className='text-lg md:text-xl font-bold mb-4'>
+          Status Distribution
+        </h3>
+        <div className='h-64 flex items-center justify-center text-default-400'>
+          No data available
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-content1 p-4 md:p-6 rounded-lg border border-divider'>
+      <h3 className='text-lg md:text-xl font-bold mb-4'>
+        Status Distribution
+      </h3>
+
+      {/* Mobile Layout */}
+      <div className='md:hidden'>
+        <div className='h-48 mb-4'>
+          <ResponsiveContainer width='100%' height='100%'>
+            <PieChart>
+              <Pie
+                data={sortedData}
+                cx='50%'
+                cy='50%'
+                innerRadius={35}
+                outerRadius={70}
+                paddingAngle={2}
+                dataKey='value'
+              >
+                {sortedData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip content={<CustomTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <div className='grid grid-cols-2 gap-2'>
+          {sortedData.map((entry, index) => (
+            <div key={index} className='flex items-center gap-2'>
+              <div
+                className='w-3 h-3 rounded-full flex-shrink-0'
+                style={{ backgroundColor: entry.color }}
+              />
+              <span className='text-xs font-medium truncate'>
+                {entry.name} ({entry.value})
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Desktop Layout */}
+      <div className='hidden md:block'>
+        <div className='h-64 flex'>
+          <div className='flex-1'>
+            <ResponsiveContainer width='100%' height='100%'>
+              <PieChart>
+                <Pie
+                  data={sortedData}
+                  cx='50%'
+                  cy='50%'
+                  innerRadius={50}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  dataKey='value'
+                >
+                  {sortedData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip content={<CustomTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className='w-44 flex flex-col justify-center pl-4'>
+            <div className='space-y-3'>
+              {sortedData.map((entry, index) => (
+                <div key={index} className='flex items-center gap-2'>
+                  <div
+                    className='w-3 h-3 rounded-full'
+                    style={{ backgroundColor: entry.color }}
+                  />
+                  <span className='text-sm font-medium'>
+                    {entry.name} ({entry.value})
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hooks/useBookingAnalytics.ts
+++ b/hooks/useBookingAnalytics.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+
+export type AnalyticsPeriod = '7d' | '30d' | '90d' | '1y' | 'all';
+
+interface ExtrasStat {
+  count: number;
+  rate: number;
+}
+
+export interface BookingAnalyticsData {
+  summary: {
+    totalRevenue: number;
+    totalBookings: number;
+    avgBookingValue: number;
+    cancellationRate: number;
+  };
+  revenueOverTime: {
+    date: string;
+    revenue: number;
+    bookings: number;
+  }[];
+  statusDistribution: {
+    status: string;
+    count: number;
+  }[];
+  popularCabins: {
+    name: string;
+    bookingCount: number;
+    revenue: number;
+  }[];
+  demographics: {
+    avgPartySize: number;
+    avgStayLength: number;
+    extras: {
+      breakfast: ExtrasStat;
+      pets: ExtrasStat;
+      parking: ExtrasStat;
+      earlyCheckIn: ExtrasStat;
+      lateCheckOut: ExtrasStat;
+    };
+  };
+}
+
+export function useBookingAnalytics(period: AnalyticsPeriod = '30d') {
+  return useQuery<BookingAnalyticsData>({
+    queryKey: ['booking-analytics', period],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/bookings/analytics?period=${period}`
+      );
+      if (!response.ok) {
+        throw new Error('Failed to fetch booking analytics');
+      }
+      const result = await response.json();
+      return result.success ? result.data : result;
+    },
+  });
+}

--- a/hooks/useBookings.ts
+++ b/hooks/useBookings.ts
@@ -184,6 +184,7 @@ export const useCreateBooking = () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
       queryClient.invalidateQueries({ queryKey: ['activities'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
+      queryClient.invalidateQueries({ queryKey: ['booking-analytics'] });
       // Note: SWR will be revalidated automatically on focus or manually via mutate
     },
   });
@@ -220,6 +221,7 @@ export const useRecordPayment = () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
       queryClient.invalidateQueries({ queryKey: ['activities'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
+      queryClient.invalidateQueries({ queryKey: ['booking-analytics'] });
     },
   });
 };
@@ -249,6 +251,7 @@ export const useUpdateBooking = () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
       queryClient.invalidateQueries({ queryKey: ['activities'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
+      queryClient.invalidateQueries({ queryKey: ['booking-analytics'] });
       addToast({
         title: 'Booking updated',
         description: 'The booking has been updated successfully.',
@@ -283,6 +286,7 @@ export const useDeleteBooking = () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
       queryClient.invalidateQueries({ queryKey: ['activities'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
+      queryClient.invalidateQueries({ queryKey: ['booking-analytics'] });
     },
   });
 };
@@ -315,6 +319,7 @@ export const useCheckInBooking = () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
       queryClient.invalidateQueries({ queryKey: ['activities'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
+      queryClient.invalidateQueries({ queryKey: ['booking-analytics'] });
     },
   });
 };
@@ -347,6 +352,7 @@ export const useCheckOutBooking = () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
       queryClient.invalidateQueries({ queryKey: ['activities'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
+      queryClient.invalidateQueries({ queryKey: ['booking-analytics'] });
     },
   });
 };
@@ -378,6 +384,7 @@ export const useConfirmBooking = () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
       queryClient.invalidateQueries({ queryKey: ['activities'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
+      queryClient.invalidateQueries({ queryKey: ['booking-analytics'] });
     },
   });
 };


### PR DESCRIPTION
## Summary
- Adds a comprehensive booking analytics page at `/bookings/analytics` with time period filtering (7d, 30d, 90d, 1y, All Time)
- Includes summary stats cards (total revenue, bookings, avg value, cancellation rate), revenue trend area chart with dual axes, status distribution pie chart, popular cabins bar chart, and guest demographics section
- Adds CSV export functionality and cache invalidation for analytics data on all booking mutations

## Test plan
- [x] Navigate to `/bookings` and verify "Analytics" button appears next to "New Booking"
- [x] Click "Analytics" and verify the dashboard loads with stats, charts, and demographics
- [x] Switch between time periods (7d, 30d, 90d, 1y, All) and verify data updates
- [x] Click "Export CSV" and verify downloaded file contains all analytics sections
- [ ] Create/update/delete a booking, return to analytics, and verify data refreshes
- [x] Run `pnpm lint` and `pnpm check:types` to confirm no new errors

Closes #2