### PR TITLE
feat: align cabin model with customer portal

### DIFF
--- a/__tests__/validations/cabin.test.ts
+++ b/__tests__/validations/cabin.test.ts
@@ -139,31 +139,20 @@ describe('Cabin Validation Schemas', () => {
       expect(result.success).toBe(false);
     });
 
-    it('accepts amenities object', () => {
+    it('accepts amenities string array', () => {
       const cabin = {
         ...validCabin,
-        amenities: {
-          wifi: true,
-          tv: true,
-          pool: false,
-          hotTub: true,
-        },
+        amenities: ['wifi', 'tv', 'pool'],
       };
       const result = createCabinSchema.safeParse(cabin);
       expect(result.success).toBe(true);
     });
 
-    it('applies default amenities values', () => {
-      const cabin = {
-        ...validCabin,
-        amenities: {},
-      };
-      const result = createCabinSchema.safeParse(cabin);
+    it('applies default amenities value (empty array)', () => {
+      const result = createCabinSchema.safeParse(validCabin);
       expect(result.success).toBe(true);
-      if (result.success && result.data.amenities) {
-        expect(result.data.amenities.wifi).toBe(true);
-        expect(result.data.amenities.tv).toBe(true);
-        expect(result.data.amenities.pool).toBe(false);
+      if (result.success) {
+        expect(result.data.amenities).toEqual([]);
       }
     });
   });

--- a/lib/validations/cabin.ts
+++ b/lib/validations/cabin.ts
@@ -1,24 +1,6 @@
 import { z } from 'zod';
 
 /**
- * Cabin amenities schema
- */
-const amenitiesSchema = z.object({
-  wifi: z.boolean().optional().default(true),
-  tv: z.boolean().optional().default(true),
-  airConditioning: z.boolean().optional().default(true),
-  heating: z.boolean().optional().default(true),
-  kitchen: z.boolean().optional().default(false),
-  washer: z.boolean().optional().default(false),
-  parking: z.boolean().optional().default(false),
-  pool: z.boolean().optional().default(false),
-  hotTub: z.boolean().optional().default(false),
-  fireplace: z.boolean().optional().default(false),
-  balcony: z.boolean().optional().default(false),
-  petFriendly: z.boolean().optional().default(false),
-});
-
-/**
  * Create cabin request schema
  */
 export const createCabinSchema = z
@@ -27,12 +9,12 @@ export const createCabinSchema = z
     description: z
       .string()
       .min(10, 'Description must be at least 10 characters')
-      .max(2000),
+      .max(1000),
     capacity: z.number().int().min(1, 'Capacity must be at least 1').max(20),
     price: z.number().positive('Price must be positive'),
     discount: z.number().min(0).optional().default(0),
     image: z.string().url('Invalid image URL').optional(),
-    amenities: amenitiesSchema.optional(),
+    amenities: z.array(z.string().trim().min(1)).optional().default([]),
     isAvailable: z.boolean().optional().default(true),
   })
   .refine(data => !data.discount || data.discount < data.price, {
@@ -52,7 +34,7 @@ export const updateCabinSchema = z
     price: z.number().positive().optional(),
     discount: z.number().min(0).optional(),
     image: z.string().url().optional(),
-    amenities: amenitiesSchema.optional(),
+    amenities: z.array(z.string().trim().min(1)).optional().default([]),
     isAvailable: z.boolean().optional(),
   })
   .refine(

--- a/models/Cabin.ts
+++ b/models/Cabin.ts
@@ -52,6 +52,12 @@ const CabinSchema: Schema = new Schema(
       type: Number,
       default: 0,
       min: [0, 'Discount must be positive'],
+      validate: {
+        validator: function (this: ICabin, value: number) {
+          return value < this.price;
+        },
+        message: 'Discount must be less than the cabin price',
+      },
     },
     description: {
       type: String,


### PR DESCRIPTION
## Summary
- **Amenities**: Changed from a boolean object schema to a simple string array to align with the customer portal's data model
- **Cabin model**: Added discount validation (must be less than cabin price) at the Mongoose schema level
- **Validation**: Reduced description max length from 2000 to 1000 characters, updated tests to match new amenities format

## Test plan
- [x] Verify `pnpm test` passes with updated cabin validation tests
- [x] Confirm cabin creation/editing works with string array amenities
- [x] Test that discount >= price is rejected at the model level