### PR TITLE
Fix security and performance issues found in codebase audit

### DIFF
--- a/__tests__/api/experiences.test.ts
+++ b/__tests__/api/experiences.test.ts
@@ -275,7 +275,7 @@ describe('/api/experiences/[id]', () => {
       expect(MockExperience.findByIdAndUpdate).toHaveBeenCalledWith(
         '507f1f77bcf86cd799439011',
         { name: 'Updated Adventure' },
-        { new: true }
+        { new: true, runValidators: true }
       );
       expect(response.status).toBe(200);
       expect(data).toEqual(updatedData);

--- a/__tests__/unit/lib/api-utils.test.ts
+++ b/__tests__/unit/lib/api-utils.test.ts
@@ -9,6 +9,8 @@ import {
   formatZodErrors,
   createRateLimitResponse,
   parsePagination,
+  parseIntParam,
+  sanitizeUpdatePayload,
   buildPaginationMeta,
   createPaginatedResponse,
   createValidationErrorResponse,
@@ -356,14 +358,64 @@ describe('api-utils', () => {
       expect(result.limit).toBe(API_CONFIG.MAX_PAGE_SIZE);
     });
 
-    it('returns NaN-derived values for non-numeric inputs', () => {
-      // Note: parseInt('abc') returns NaN, and Math.max(1, NaN) returns NaN
-      // This is a known edge case — callers should sanitize inputs
+    it('falls back to defaults for non-numeric inputs', () => {
       const params = new URLSearchParams({ page: 'abc', limit: 'xyz' });
       const result = parsePagination(params);
 
-      expect(result.page).toBeNaN();
-      expect(result.limit).toBeNaN();
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(API_CONFIG.DEFAULT_PAGE_SIZE);
+      expect(result.skip).toBe(0);
+    });
+  });
+
+  describe('sanitizeUpdatePayload', () => {
+    it('passes through plain fields', () => {
+      const result = sanitizeUpdatePayload({ name: 'Cabin A', price: 100 });
+
+      expect(result).toEqual({ name: 'Cabin A', price: 100 });
+    });
+
+    it('strips MongoDB operator keys', () => {
+      const result = sanitizeUpdatePayload({
+        name: 'Cabin A',
+        $inc: { price: -50 },
+        $unset: { discount: '' },
+      });
+
+      expect(result).toEqual({ name: 'Cabin A' });
+    });
+
+    it('strips dotted path keys', () => {
+      const result = sanitizeUpdatePayload({
+        name: 'Cabin A',
+        'settings.secret': true,
+      });
+
+      expect(result).toEqual({ name: 'Cabin A' });
+    });
+
+    it('strips immutable fields', () => {
+      const result = sanitizeUpdatePayload({
+        _id: 'someid',
+        __v: 3,
+        name: 'Cabin A',
+      });
+
+      expect(result).toEqual({ name: 'Cabin A' });
+    });
+  });
+
+  describe('parseIntParam', () => {
+    it('parses valid integers', () => {
+      expect(parseIntParam('42', 1)).toBe(42);
+    });
+
+    it('falls back for null', () => {
+      expect(parseIntParam(null, 7)).toBe(7);
+    });
+
+    it('falls back for non-numeric strings', () => {
+      expect(parseIntParam('abc', 7)).toBe(7);
     });
   });
 

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,11 +1,12 @@
 import {
   createValidationErrorResponse,
   escapeRegex,
+  parsePagination,
   requireApiAuth,
 } from '@/lib/api-utils';
 import { differenceInCalendarDays } from 'date-fns';
 import mongoose from 'mongoose';
-import { getClerkUsersBatch } from '@/lib/clerk-users';
+import { getClerkUsersBatch, searchClerkUsers } from '@/lib/clerk-users';
 import { VALID_TRANSITIONS } from '@/lib/config';
 import { logger } from '@/lib/logger';
 import connectDB from '@/lib/mongodb';
@@ -61,8 +62,7 @@ export async function GET(request: NextRequest) {
     await connectDB();
 
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '10');
+    const { page, limit, skip } = parsePagination(searchParams);
     const status = searchParams.get('status');
     const search = searchParams.get('search');
     const sortBy = searchParams.get('sortBy') || 'checkInDate';
@@ -74,68 +74,84 @@ export async function GET(request: NextRequest) {
       query.status = status;
     }
 
-    // Build sort object
+    // Build sort object (whitelist sortable fields — sortBy is user input)
+    const SORTABLE_FIELDS = new Set([
+      'checkInDate',
+      'checkOutDate',
+      'totalPrice',
+      'createdAt',
+      'status',
+      'numNights',
+      'numGuests',
+    ]);
+    const sortField = sortBy === 'created_at' ? 'createdAt' : sortBy;
     const sort: MongoSortOrder = {};
-    sort[sortBy] = sortOrder === 'desc' ? -1 : 1;
+    sort[SORTABLE_FIELDS.has(sortField) ? sortField : 'checkInDate'] =
+      sortOrder === 'desc' ? -1 : 1;
 
-    // If there's a search term, use optimized database queries
+    // If there's a search term, resolve matching cabins and customers first,
+    // then run a fully database-side paginated query. This keeps the search
+    // bounded — the previous approach loaded every booking into memory and
+    // fetched every customer from Clerk before paginating.
     if (search) {
       const safeSearch = escapeRegex(search);
 
-      // Phase 1: Find matching cabin IDs from database
+      // Phase 1a: Find matching cabin IDs from database
       const matchingCabins = await Cabin.find({
         name: { $regex: safeSearch, $options: 'i' },
       }).select('_id');
       const cabinIds = matchingCabins.map(c => c._id);
 
-      // Build query to find bookings matching cabin name
-      const searchQuery: BookingQueryFilter = { ...query };
-
-      if (cabinIds.length > 0) {
-        searchQuery.$or = [{ cabin: { $in: cabinIds } }];
+      // Phase 1b: Find matching customer IDs via Clerk search (name/email).
+      // Bounded to the first 100 matches to keep the query cheap.
+      let customerIds: string[] = [];
+      try {
+        const { data: matchingCustomers } = await searchClerkUsers(search, 100);
+        customerIds = matchingCustomers.map(c => c.id);
+      } catch (clerkError) {
+        logger.error('Clerk customer search failed', clerkError);
       }
 
-      // Get bookings matching the search criteria
-      const matchingBookings = await Booking.find(searchQuery)
-        .populate('cabin', 'name image capacity price discount')
-        .sort(sort);
+      if (cabinIds.length === 0 && customerIds.length === 0) {
+        return NextResponse.json({
+          success: true,
+          data: [],
+          pagination: {
+            currentPage: page,
+            totalPages: 0,
+            totalBookings: 0,
+            limit,
+            hasNextPage: false,
+            hasPrevPage: false,
+          },
+        });
+      }
 
-      // Populate with Clerk customer data
+      // Phase 2: Query bookings matching either, with DB-side pagination
+      const searchQuery: BookingQueryFilter = { ...query };
+      searchQuery.$or = [
+        ...(cabinIds.length > 0 ? [{ cabin: { $in: cabinIds } }] : []),
+        ...(customerIds.length > 0 ? [{ customer: { $in: customerIds } }] : []),
+      ];
+
+      const [matchingBookings, totalBookings] = await Promise.all([
+        Booking.find(searchQuery)
+          .populate('cabin', 'name image capacity price discount')
+          .sort(sort)
+          .skip(skip)
+          .limit(limit),
+        Booking.countDocuments(searchQuery),
+      ]);
+
+      // Populate with Clerk customer data (current page only)
       const { bookings: populatedBookings, _clerkWarning } =
         await populateBookingsWithClerkCustomers(matchingBookings);
 
-      // Additional client-side filtering for customer name/email
-      // (since Clerk data isn't in our DB, we still need some filtering)
-      const searchLower = search.toLowerCase();
-      const filteredBookings = populatedBookings.filter(booking => {
-        const cabin = booking.cabin;
-        const customer = booking.customer || booking.guest;
-
-        if (!cabin || !customer) return false;
-
-        // Check cabin name (already filtered by DB, but double-check)
-        if (cabin.name?.toLowerCase().includes(searchLower)) return true;
-
-        // Check customer name/email (Clerk data)
-        if (
-          customer.name?.toLowerCase().includes(searchLower) ||
-          customer.email?.toLowerCase().includes(searchLower)
-        ) {
-          return true;
-        }
-
-        return false;
-      });
-
-      // Apply pagination to filtered results
-      const totalBookings = filteredBookings.length;
       const totalPages = Math.ceil(totalBookings / limit);
-      const skip = (page - 1) * limit;
-      const paginatedBookings = filteredBookings.slice(skip, skip + limit);
 
       return NextResponse.json({
         success: true,
-        data: paginatedBookings,
+        data: populatedBookings,
         pagination: {
           currentPage: page,
           totalPages,
@@ -148,8 +164,6 @@ export async function GET(request: NextRequest) {
       });
     } else {
       // No search term - use database pagination for better performance
-      const skip = (page - 1) * limit;
-
       const bookings = await Booking.find(query)
         .populate('cabin', 'name image capacity price discount')
         .sort(sort)
@@ -267,6 +281,24 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { success: false, error: 'Pets are not allowed' },
         { status: 400 }
+      );
+    }
+
+    // Prevent double-bookings: reject if the cabin is already booked
+    // for an overlapping date range
+    const overlapping = await Booking.findOverlapping(
+      validationResult.data.cabin,
+      checkInDate,
+      checkOutDate
+    );
+    if (overlapping.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'The selected dates overlap with an existing booking for this cabin',
+        },
+        { status: 409 }
       );
     }
 
@@ -585,7 +617,10 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    if (updateData.totalPrice !== undefined || updateData.depositAmount !== undefined) {
+    if (
+      updateData.totalPrice !== undefined ||
+      updateData.depositAmount !== undefined
+    ) {
       const effectiveTotalPrice =
         updateData.totalPrice ?? existingBooking.totalPrice;
       const effectiveDepositAmount =

--- a/app/api/cabins/[id]/route.ts
+++ b/app/api/cabins/[id]/route.ts
@@ -1,4 +1,4 @@
-import { requireApiAuth } from '@/lib/api-utils';
+import { requireApiAuth, sanitizeUpdatePayload } from '@/lib/api-utils';
 import connectDB from '@/lib/mongodb';
 import { isMongooseValidationError } from '@/types/errors';
 import { NextRequest, NextResponse } from 'next/server';
@@ -84,10 +84,14 @@ export async function PUT(
       );
     }
 
-    const cabin = await Cabin.findByIdAndUpdate(id, body, {
-      new: true,
-      runValidators: true,
-    });
+    const cabin = await Cabin.findByIdAndUpdate(
+      id,
+      sanitizeUpdatePayload(body),
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
 
     if (!cabin) {
       return NextResponse.json(

--- a/app/api/cabins/route.ts
+++ b/app/api/cabins/route.ts
@@ -4,6 +4,7 @@ import {
   escapeRegex,
   HTTP_STATUS,
   requireApiAuth,
+  sanitizeUpdatePayload,
 } from '@/lib/api-utils';
 import connectDB from '@/lib/mongodb';
 import type { CabinQueryFilter, MongoSortOrder } from '@/types/api';
@@ -89,9 +90,18 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Build sort object
+    // Build sort object (whitelist sortable fields — sortBy is user input)
+    const SORTABLE_FIELDS = new Set([
+      'name',
+      'price',
+      'capacity',
+      'discount',
+      'status',
+      'createdAt',
+    ]);
     const sort: MongoSortOrder = {};
-    sort[sortBy] = sortOrder === 'desc' ? -1 : 1;
+    sort[SORTABLE_FIELDS.has(sortBy) ? sortBy : 'name'] =
+      sortOrder === 'desc' ? -1 : 1;
 
     const cabins = await Cabin.find(query).sort(sort);
 
@@ -163,10 +173,14 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const cabin = await Cabin.findByIdAndUpdate(_id, updateData, {
-      new: true,
-      runValidators: true,
-    });
+    const cabin = await Cabin.findByIdAndUpdate(
+      _id,
+      sanitizeUpdatePayload(updateData),
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
 
     if (!cabin) {
       return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -1,6 +1,7 @@
 import {
   createRateLimitResponse,
   createValidationErrorResponse,
+  parsePagination,
   requireApiAuth,
 } from '@/lib/api-utils';
 import {
@@ -28,14 +29,10 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get('page') || '1');
-    const limit = parseInt(searchParams.get('limit') || '10');
+    const { page, limit, skip: offset } = parsePagination(searchParams);
     const search = searchParams.get('search');
     const sortBy = searchParams.get('sortBy') || 'created_at';
     const sortOrder = searchParams.get('sortOrder') || 'desc';
-
-    // Calculate pagination
-    const offset = (page - 1) * limit;
 
     // Map sortBy to valid Clerk fields
     let clerkSortBy = 'created_at';

--- a/app/api/dining/[id]/route.ts
+++ b/app/api/dining/[id]/route.ts
@@ -1,4 +1,4 @@
-import { requireApiAuth } from '@/lib/api-utils';
+import { requireApiAuth, sanitizeUpdatePayload } from '@/lib/api-utils';
 import { connectDB, Dining } from '@/models';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -64,10 +64,14 @@ export async function PUT(
       }
     }
 
-    const dining = await Dining.findByIdAndUpdate(id, body, {
-      new: true,
-      runValidators: true,
-    });
+    const dining = await Dining.findByIdAndUpdate(
+      id,
+      sanitizeUpdatePayload(body),
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
 
     if (!dining) {
       return NextResponse.json(

--- a/app/api/dining/route.ts
+++ b/app/api/dining/route.ts
@@ -4,6 +4,7 @@ import {
   escapeRegex,
   HTTP_STATUS,
   requireApiAuth,
+  sanitizeUpdatePayload,
 } from '@/lib/api-utils';
 import { connectDB, Dining } from '@/models';
 import type { DiningQueryFilter, MongoSortOrder } from '@/types/api';
@@ -60,9 +61,19 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Build sort object
+    // Build sort object (whitelist sortable fields — sortBy is user input)
+    const SORTABLE_FIELDS = new Set([
+      'name',
+      'price',
+      'type',
+      'mealType',
+      'category',
+      'maxPeople',
+      'createdAt',
+    ]);
     const sort: MongoSortOrder = {};
-    sort[sortBy] = sortOrder === 'asc' ? 1 : -1;
+    sort[SORTABLE_FIELDS.has(sortBy) ? sortBy : 'name'] =
+      sortOrder === 'asc' ? 1 : -1;
 
     const dining = await Dining.find(filter).sort(sort);
 
@@ -168,10 +179,14 @@ export async function PUT(request: NextRequest) {
       }
     }
 
-    const dining = await Dining.findByIdAndUpdate(_id, updateData, {
-      new: true,
-      runValidators: true,
-    });
+    const dining = await Dining.findByIdAndUpdate(
+      _id,
+      sanitizeUpdatePayload(updateData),
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
 
     if (!dining) {
       return createErrorResponse(

--- a/app/api/experiences/[id]/route.ts
+++ b/app/api/experiences/[id]/route.ts
@@ -1,4 +1,4 @@
-import { requireApiAuth } from '@/lib/api-utils';
+import { requireApiAuth, sanitizeUpdatePayload } from '@/lib/api-utils';
 import connectToDatabase from '@/lib/mongodb';
 import { Experience } from '@/models/Experience';
 import { NextResponse } from 'next/server';
@@ -40,9 +40,14 @@ export async function PUT(request: Request, { params }: ParamProps) {
   try {
     await connectToDatabase();
     const data = await request.json();
-    const experience = await Experience.findByIdAndUpdate(id, data, {
-      new: true,
-    });
+    const experience = await Experience.findByIdAndUpdate(
+      id,
+      sanitizeUpdatePayload(data),
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
     if (!experience) {
       return NextResponse.json(
         { error: 'Experience not found' },

--- a/app/api/experiences/route.ts
+++ b/app/api/experiences/route.ts
@@ -38,9 +38,18 @@ export async function GET(request: NextRequest) {
       query.difficulty = difficulty;
     }
 
-    // Build sort
+    // Build sort (whitelist sortable fields — sortBy is user input)
+    const SORTABLE_FIELDS = new Set([
+      'name',
+      'price',
+      'duration',
+      'difficulty',
+      'category',
+      'isPopular',
+      'createdAt',
+    ]);
     const sort: Record<string, 1 | -1> = {};
-    if (sortBy) {
+    if (sortBy && SORTABLE_FIELDS.has(sortBy)) {
       sort[sortBy] = sortOrder;
     }
 

--- a/app/api/send/welcome/route.ts
+++ b/app/api/send/welcome/route.ts
@@ -5,6 +5,7 @@ import {
   RATE_LIMIT_CONFIGS,
 } from '@/lib/rate-limit';
 import { WelcomeEmail } from '@/components/EmailTemplates';
+import { validateEmail } from '@/utils/utilityFunctions';
 import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -26,6 +27,10 @@ export async function POST(request: Request) {
 
   const { firstName, email } = await request.json();
   try {
+    if (!validateEmail(email)) {
+      return Response.json({ error: 'Invalid email address' }, { status: 400 });
+    }
+
     const { data, error } = await resend.emails.send({
       from: 'LodgeFlow <onboarding@resend.dev>',
       to: email,

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -177,6 +177,34 @@ export function escapeRegex(str: string): string {
 }
 
 /**
+ * Sanitize a client-supplied update payload before passing it to
+ * findByIdAndUpdate / findOneAndUpdate. Strips MongoDB operator keys
+ * ($set, $inc, ...), dotted paths, and immutable fields so a request
+ * body can't smuggle update operators past schema validation.
+ */
+export function sanitizeUpdatePayload(
+  payload: Record<string, unknown>
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (key.startsWith('$') || key.includes('.')) continue;
+    if (key === '_id' || key === '__v') continue;
+    sanitized[key] = value;
+  }
+
+  return sanitized;
+}
+
+/**
+ * Parse an integer query param, falling back when missing or malformed
+ */
+export function parseIntParam(value: string | null, fallback: number): number {
+  const parsed = parseInt(value ?? '', 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+/**
  * Handle common API errors with appropriate status codes
  */
 export function handleApiError(error: unknown): NextResponse<ApiErrorResponse> {
@@ -307,14 +335,12 @@ export function parsePagination(searchParams: URLSearchParams): {
   limit: number;
   skip: number;
 } {
-  const page = Math.max(1, parseInt(searchParams.get('page') || '1'));
+  const page = Math.max(1, parseIntParam(searchParams.get('page'), 1));
   const limit = Math.min(
     API_CONFIG.MAX_PAGE_SIZE,
     Math.max(
       1,
-      parseInt(
-        searchParams.get('limit') || String(API_CONFIG.DEFAULT_PAGE_SIZE)
-      )
+      parseIntParam(searchParams.get('limit'), API_CONFIG.DEFAULT_PAGE_SIZE)
     )
   );
   const skip = (page - 1) * limit;

--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,30 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ['@heroui/react', '@heroui/button', '@heroui/card'],
   },
+  // Security headers
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary

Fixes 8 security/correctness/performance issues found during a codebase audit of the API surface.

### Security

- **MongoDB update-operator injection**: cabins, dining, and experiences PUT handlers passed the raw JSON body straight into `findByIdAndUpdate`, so a body like `{"$inc": {"price": -100}}` executed as an update operator and bypassed schema validators. Added a `sanitizeUpdatePayload()` helper in `lib/api-utils.ts` (strips `$`-prefixed keys, dotted paths, `_id`/`__v`) and applied it at all five call sites. Experiences PUT also now runs `runValidators: true` (previously no validation at all).
- **Sort-field injection**: `sortBy` from the query string was used directly as a MongoDB sort key in bookings, cabins, dining, and experiences GET. Each route now whitelists its sortable fields with a fallback.
- **Missing email validation** in `/api/send/welcome` (its sibling `/confirm` route already had it).
- **Security headers**: added `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, and HSTS via `headers()` in `next.config.js`.

### Correctness

- **Double-booking prevention on create**: `POST /api/bookings` never called `Booking.findOverlapping()` — the guard existed only on update. Two bookings for the same cabin and overlapping dates could be created. Now checked before create, returning 409 on conflict.
- **NaN-safe pagination**: non-numeric `page`/`limit` values fell through `parseInt` as `NaN` and broke skip/limit (including inside the shared `parsePagination()` helper).

### Performance

- **Unbounded pagination**: bookings and customers GET accepted any `limit` (`?limit=1000000` pulled the whole collection, and for bookings triggered a Clerk fetch per customer). Both now use `parsePagination()` clamped to `MAX_PAGE_SIZE` (100).
- **Bookings search rewritten to stay database-side**: when a search term matched no cabin name, the old code loaded *every* booking into memory, fetched every unique customer from Clerk (serialized at 100ms+ per uncached call), then filtered and paginated in JS. Now it resolves matching cabin IDs and Clerk customer IDs first (Clerk user search covers name/email, bounded to 100 matches), then runs one `$or` query with DB-side sort/skip/limit and count. Only the current page's customers are fetched from Clerk.

### Tests

- Updated the experiences PUT call-shape assertion for `runValidators`.
- Replaced the test that documented the `parsePagination` NaN edge case as "known" with an assertion of the fixed behavior.
- Added unit coverage for `sanitizeUpdatePayload` and `parseIntParam`.

## Verification

- `tsc --noEmit` clean; ESLint clean on changed files.
- jsdom Jest project: 363/364 pass. The one failure (`__tests__/validations/experience.test.ts` › "applies defaults") is pre-existing on `main` — verified by stashing these changes and re-running.
- The node/integration project could not run in the sandbox (MongoDB Memory Server binary download blocked by the environment proxy) — please rely on CI/local for that suite.

Known remaining gaps are tracked as separate issues (unwired Zod schemas, client-supplied pricing on booking create, overlap-check race window, and others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwDvDwkws8yKw3wZmLP9mu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwDvDwkws8yKw3wZmLP9mu)_