### PR TITLE
Fix issue 112: Remove stats sorting from customers UI

### DIFF
--- a/app/(dashboard)/guests/page.tsx
+++ b/app/(dashboard)/guests/page.tsx
@@ -64,8 +64,6 @@ function GuestsContent() {
 
   const sortOptions: FilterOption[] = [
     { key: 'name', label: 'Name', value: 'name' },
-    { key: 'totalSpent', label: 'Spending', value: 'totalSpent' },
-    { key: 'totalBookings', label: 'Bookings', value: 'totalBookings' },
   ];
 
   const handleSearch = (value: string) => {

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -112,14 +112,7 @@ export async function GET(request: NextRequest) {
       };
     });
 
-    // Sort by stats fields in-memory (not available in Clerk)
-    if (sortBy === 'totalSpent' || sortBy === 'totalBookings') {
-      enrichedData.sort((a, b) => {
-        const aVal = a[sortBy];
-        const bVal = b[sortBy];
-        return sortOrder === 'desc' ? bVal - aVal : aVal - bVal;
-      });
-    }
+
 
     return NextResponse.json({
       success: true,

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -112,8 +112,6 @@ export async function GET(request: NextRequest) {
       };
     });
 
-
-
     return NextResponse.json({
       success: true,
       data: enrichedData,

--- a/hooks/useURLFilters.ts
+++ b/hooks/useURLFilters.ts
@@ -212,7 +212,7 @@ export const guestsFilterConfig: URLFilterConfig = {
   sortBy: {
     type: 'string',
     defaultValue: 'name',
-    validValues: ['name', 'totalSpent', 'totalBookings', 'created_at'],
+    validValues: ['name', 'created_at'],
   },
   sortOrder: {
     type: 'string',


### PR DESCRIPTION
Closes #112. The stats sorting for totalSpent and totalBookings was only sorting the paginated results returned from Clerk, which was misleading. Following the suggested workaround in the issue, this PR drops the two stats sort options from the UI until a real implementation exists.