### PR TITLE
Add Zod validation to Settings PUT endpoint

### DIFF
--- a/__tests__/api/settings.test.ts
+++ b/__tests__/api/settings.test.ts
@@ -153,6 +153,28 @@ describe('/api/settings', () => {
       expect(data.success).toBe(true);
     });
 
+    it('should reject invalid settings payload with structured errors', async () => {
+      const settingsWithSave = {
+        ...mockSettingsData,
+        save: mockSave.mockResolvedValue(mockSettingsData),
+      };
+      (mockSettings.findOne as jest.Mock).mockResolvedValue(settingsWithSave);
+
+      const request = new NextRequest('http://localhost/api/settings', {
+        method: 'PUT',
+        body: JSON.stringify({ depositPercentage: 200 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details).toBeDefined();
+      expect(mockSave).not.toHaveBeenCalled();
+    });
+
     it('should create new settings if none exist on update', async () => {
       (mockSettings.findOne as jest.Mock).mockResolvedValue(null);
       (mockSettings.create as jest.Mock).mockResolvedValue(mockSettingsData);

--- a/__tests__/integration/api/settings.test.ts
+++ b/__tests__/integration/api/settings.test.ts
@@ -1,0 +1,140 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/mongodb', () => jest.fn().mockResolvedValue(undefined));
+
+import { PUT } from '@/app/api/settings/route';
+import Settings from '@/models/Settings';
+import { settingsData } from '@/lib/data/seed-data';
+
+function createRequest(body: unknown) {
+  return new NextRequest(new URL('http://localhost:3000/api/settings'), {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function createDefaultSettings() {
+  return Settings.create({
+    ...settingsData,
+    businessHours: {
+      open: '09:00',
+      close: '18:00',
+      daysOpen: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+    },
+    notifications: {
+      emailEnabled: true,
+      smsEnabled: false,
+      bookingConfirmation: true,
+      paymentReminders: true,
+      checkInReminders: true,
+    },
+  });
+}
+
+describe('Settings API Routes', () => {
+  describe('PUT /api/settings', () => {
+    it('updates settings with a valid partial payload', async () => {
+      await createDefaultSettings();
+
+      const response = await PUT(
+        createRequest({ breakfastPrice: 22, depositPercentage: 30 })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.breakfastPrice).toBe(22);
+      expect(data.data.depositPercentage).toBe(30);
+    });
+
+    it('accepts payloads that include MongoDB metadata fields', async () => {
+      const settings = await createDefaultSettings();
+
+      const response = await PUT(
+        createRequest({
+          _id: settings._id.toString(),
+          createdAt: settings.createdAt,
+          updatedAt: settings.updatedAt,
+          breakfastPrice: 18,
+        })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.breakfastPrice).toBe(18);
+    });
+
+    it('returns 400 with structured errors for out-of-range values', async () => {
+      await createDefaultSettings();
+
+      const response = await PUT(
+        createRequest({ depositPercentage: 150 })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details).toBeDefined();
+      expect(data.details.depositPercentage).toBeDefined();
+    });
+
+    it('returns 400 with structured errors for unknown keys', async () => {
+      await createDefaultSettings();
+
+      const response = await PUT(
+        createRequest({ breakfastPrice: 20, taxRate: 5 })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details).toBeDefined();
+    });
+
+    it('returns 400 when minBookingLength exceeds existing maxBookingLength', async () => {
+      await Settings.create({
+        ...settingsData,
+        minBookingLength: 2,
+        maxBookingLength: 10,
+        businessHours: {
+          open: '09:00',
+          close: '18:00',
+          daysOpen: ['monday'],
+        },
+        notifications: {
+          emailEnabled: true,
+          smsEnabled: false,
+          bookingConfirmation: true,
+          paymentReminders: true,
+          checkInReminders: true,
+        },
+      });
+
+      const response = await PUT(createRequest({ minBookingLength: 15 }));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details.maxBookingLength).toBeDefined();
+    });
+
+    it('returns 400 when both booking lengths are invalid in the payload', async () => {
+      await createDefaultSettings();
+
+      const response = await PUT(
+        createRequest({ minBookingLength: 20, maxBookingLength: 10 })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details).toBeDefined();
+    });
+  });
+});

--- a/__tests__/integration/api/settings.test.ts
+++ b/__tests__/integration/api/settings.test.ts
@@ -69,9 +69,7 @@ describe('Settings API Routes', () => {
     it('returns 400 with structured errors for out-of-range values', async () => {
       await createDefaultSettings();
 
-      const response = await PUT(
-        createRequest({ depositPercentage: 150 })
-      );
+      const response = await PUT(createRequest({ depositPercentage: 150 }));
       const data = await response.json();
 
       expect(response.status).toBe(400);

--- a/__tests__/validations/settings.test.ts
+++ b/__tests__/validations/settings.test.ts
@@ -1,0 +1,129 @@
+import {
+  getBookingLengthRangeError,
+  stripSettingsMongoMetadata,
+  updateSettingsSchema,
+} from '@/lib/validations/settings';
+
+describe('Settings Validation Schemas', () => {
+  describe('updateSettingsSchema', () => {
+    it('accepts valid partial updates', () => {
+      const result = updateSettingsSchema.safeParse({
+        breakfastPrice: 20,
+        depositPercentage: 25,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts empty object for no-op partial update', () => {
+      const result = updateSettingsSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects out-of-range depositPercentage', () => {
+      const result = updateSettingsSchema.safeParse({ depositPercentage: 101 });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects negative breakfastPrice', () => {
+      const result = updateSettingsSchema.safeParse({ breakfastPrice: -1 });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects minBookingLength below 1', () => {
+      const result = updateSettingsSchema.safeParse({ minBookingLength: 0 });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects maxBookingLength above 365', () => {
+      const result = updateSettingsSchema.safeParse({ maxBookingLength: 400 });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects minBookingLength greater than maxBookingLength in payload', () => {
+      const result = updateSettingsSchema.safeParse({
+        minBookingLength: 10,
+        maxBookingLength: 5,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(issue => issue.path.includes('maxBookingLength'))
+        ).toBe(true);
+      }
+    });
+
+    it('rejects unknown keys via strict mode', () => {
+      const result = updateSettingsSchema.safeParse({
+        breakfastPrice: 20,
+        taxRate: 10,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid cancellationPolicy', () => {
+      const result = updateSettingsSchema.safeParse({
+        cancellationPolicy: 'lenient',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid checkInTime format', () => {
+      const result = updateSettingsSchema.safeParse({
+        checkInTime: '25:00',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects lowercase currency code', () => {
+      const result = updateSettingsSchema.safeParse({ currency: 'usd' });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts uppercase 3-character currency code', () => {
+      const result = updateSettingsSchema.safeParse({ currency: 'EUR' });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts nested businessHours updates', () => {
+      const result = updateSettingsSchema.safeParse({
+        businessHours: {
+          open: '08:00',
+          close: '20:00',
+          daysOpen: ['monday', 'tuesday'],
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('stripSettingsMongoMetadata', () => {
+    it('removes MongoDB metadata fields before validation', () => {
+      const cleaned = stripSettingsMongoMetadata({
+        _id: '507f1f77bcf86cd799439011',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+        __v: 0,
+        breakfastPrice: 20,
+      });
+
+      const result = updateSettingsSchema.safeParse(cleaned);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.breakfastPrice).toBe(20);
+      }
+    });
+  });
+
+  describe('getBookingLengthRangeError', () => {
+    it('returns null when min is less than or equal to max', () => {
+      expect(getBookingLengthRangeError(2, 30)).toBeNull();
+      expect(getBookingLengthRangeError(5, 5)).toBeNull();
+    });
+
+    it('returns error message when min exceeds max', () => {
+      expect(getBookingLengthRangeError(10, 5)).toBe(
+        'Maximum booking length must be greater than or equal to minimum booking length'
+      );
+    });
+  });
+});

--- a/__tests__/validations/settings.test.ts
+++ b/__tests__/validations/settings.test.ts
@@ -47,7 +47,9 @@ describe('Settings Validation Schemas', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(
-          result.error.issues.some(issue => issue.path.includes('maxBookingLength'))
+          result.error.issues.some(issue =>
+            issue.path.includes('maxBookingLength')
+          )
         ).toBe(true);
       }
     });

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,7 +1,16 @@
-import { requireApiAuth } from '@/lib/api-utils';
+import {
+  createErrorResponse,
+  createValidationErrorResponse,
+  requireApiAuth,
+} from '@/lib/api-utils';
 import { AUTHORIZED_ROLES, isAuthBypassEnabled } from '@/lib/auth-helpers';
 import { settingsData } from '@/lib/data/seed-data';
 import connectDB from '@/lib/mongodb';
+import {
+  getBookingLengthRangeError,
+  stripSettingsMongoMetadata,
+  updateSettingsSchema,
+} from '@/lib/validations/settings';
 import { isMongooseValidationError } from '@/types/errors';
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
@@ -87,16 +96,45 @@ export async function PUT(request: NextRequest) {
 
     const body = await request.json();
 
+    const validationResult = updateSettingsSchema.safeParse(
+      typeof body === 'object' && body !== null
+        ? stripSettingsMongoMetadata(body as Record<string, unknown>)
+        : body
+    );
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
+    }
+
     // Get current settings or create new if none exist
     let settings = await Settings.findOne();
 
+    const effectiveMinBookingLength =
+      validationResult.data.minBookingLength ?? settings?.minBookingLength;
+    const effectiveMaxBookingLength =
+      validationResult.data.maxBookingLength ?? settings?.maxBookingLength;
+
+    if (
+      effectiveMinBookingLength !== undefined &&
+      effectiveMaxBookingLength !== undefined
+    ) {
+      const rangeError = getBookingLengthRangeError(
+        effectiveMinBookingLength,
+        effectiveMaxBookingLength
+      );
+      if (rangeError) {
+        return createErrorResponse('Validation failed', 400, {
+          maxBookingLength: [rangeError],
+        });
+      }
+    }
+
     if (settings) {
       // Update existing settings
-      Object.assign(settings, body);
+      Object.assign(settings, validationResult.data);
       await settings.save();
     } else {
       // Create new settings
-      settings = await Settings.create(body);
+      settings = await Settings.create(validationResult.data);
     }
 
     return NextResponse.json({

--- a/lib/validations/index.ts
+++ b/lib/validations/index.ts
@@ -8,3 +8,4 @@ export * from './cabin';
 export * from './customer';
 export * from './dining';
 export * from './experience';
+export * from './settings';

--- a/lib/validations/settings.ts
+++ b/lib/validations/settings.ts
@@ -1,0 +1,177 @@
+import { z } from 'zod';
+
+const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
+
+const dayOfWeekSchema = z.enum([
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+]);
+
+const addressSchema = z
+  .object({
+    street: z.string().max(200).optional(),
+    city: z.string().max(100).optional(),
+    state: z.string().max(100).optional(),
+    country: z.string().max(100).optional(),
+    zipCode: z.string().max(20).optional(),
+  })
+  .strict();
+
+const contactInfoSchema = z
+  .object({
+    phone: z
+      .string()
+      .regex(/^[+]?[1-9][\d]{0,15}$/, 'Please provide a valid phone number')
+      .optional(),
+    email: z.string().email('Please provide a valid email address').optional(),
+    address: addressSchema.optional(),
+  })
+  .strict();
+
+const businessHoursSchema = z
+  .object({
+    open: z
+      .string()
+      .regex(timeRegex, 'Business open time must be in HH:MM format')
+      .optional(),
+    close: z
+      .string()
+      .regex(timeRegex, 'Business close time must be in HH:MM format')
+      .optional(),
+    daysOpen: z.array(dayOfWeekSchema).optional(),
+  })
+  .strict();
+
+const notificationsSchema = z
+  .object({
+    emailEnabled: z.boolean().optional(),
+    smsEnabled: z.boolean().optional(),
+    bookingConfirmation: z.boolean().optional(),
+    paymentReminders: z.boolean().optional(),
+    checkInReminders: z.boolean().optional(),
+  })
+  .strict();
+
+const cancellationPolicySchema = z.enum(['flexible', 'moderate', 'strict']);
+
+const settingsFieldsSchema = z.object({
+  minBookingLength: z
+    .number()
+    .int()
+    .min(1, 'Minimum booking length must be at least 1 day')
+    .max(30, 'Minimum booking length cannot exceed 30 days')
+    .optional(),
+  maxBookingLength: z
+    .number()
+    .int()
+    .min(1, 'Maximum booking length must be at least 1 day')
+    .max(365, 'Maximum booking length cannot exceed 365 days')
+    .optional(),
+  maxGuestsPerBooking: z
+    .number()
+    .int()
+    .min(1, 'Maximum guests must be at least 1')
+    .max(50, 'Maximum guests cannot exceed 50')
+    .optional(),
+  breakfastPrice: z
+    .number()
+    .min(0, 'Breakfast price must be positive')
+    .optional(),
+  checkInTime: z
+    .string()
+    .regex(timeRegex, 'Check-in time must be in HH:MM format')
+    .optional(),
+  checkOutTime: z
+    .string()
+    .regex(timeRegex, 'Check-out time must be in HH:MM format')
+    .optional(),
+  cancellationPolicy: cancellationPolicySchema.optional(),
+  requireDeposit: z.boolean().optional(),
+  depositPercentage: z
+    .number()
+    .min(0, 'Deposit percentage must be positive')
+    .max(100, 'Deposit percentage cannot exceed 100')
+    .optional(),
+  allowPets: z.boolean().optional(),
+  petFee: z.number().min(0, 'Pet fee must be positive').optional(),
+  smokingAllowed: z.boolean().optional(),
+  earlyCheckInFee: z
+    .number()
+    .min(0, 'Early check-in fee must be positive')
+    .optional(),
+  lateCheckOutFee: z
+    .number()
+    .min(0, 'Late check-out fee must be positive')
+    .optional(),
+  wifiIncluded: z.boolean().optional(),
+  parkingIncluded: z.boolean().optional(),
+  parkingFee: z.number().min(0, 'Parking fee must be positive').optional(),
+  currency: z
+    .string()
+    .length(3, 'Currency code must be 3 characters')
+    .regex(/^[A-Z]{3}$/, 'Currency code must be 3 uppercase characters')
+    .optional(),
+  timezone: z.string().max(100).optional(),
+  businessHours: businessHoursSchema.optional(),
+  contactInfo: contactInfoSchema.optional(),
+  notifications: notificationsSchema.optional(),
+});
+
+export const updateSettingsSchema = settingsFieldsSchema
+  .strict()
+  .superRefine((data, ctx) => {
+    if (
+      data.minBookingLength !== undefined &&
+      data.maxBookingLength !== undefined &&
+      data.minBookingLength > data.maxBookingLength
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Maximum booking length must be greater than or equal to minimum booking length',
+        path: ['maxBookingLength'],
+      });
+    }
+  });
+
+export type UpdateSettingsInput = z.infer<typeof updateSettingsSchema>;
+
+const MONGO_METADATA_KEYS = [
+  '_id',
+  'id',
+  'createdAt',
+  'updatedAt',
+  '__v',
+] as const;
+
+export function stripSettingsMongoMetadata(
+  body: Record<string, unknown>
+): Record<string, unknown> {
+  const cleaned = { ...body };
+  for (const key of MONGO_METADATA_KEYS) {
+    delete cleaned[key];
+  }
+  return cleaned;
+}
+
+export function getBookingLengthRangeError(
+  minBookingLength: number,
+  maxBookingLength: number
+): string | null {
+  if (minBookingLength > maxBookingLength) {
+    return 'Maximum booking length must be greater than or equal to minimum booking length';
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #111.

## Summary
- Adds `lib/validations/settings.ts` with `updateSettingsSchema` — partial update, `.strict()`, per-field ranges mirroring `models/Settings.ts`, and `minBookingLength <= maxBookingLength` cross-field rule
- Wires `app/api/settings/route.ts` PUT through `safeParse` + `createValidationErrorResponse` before `Object.assign`; only validated fields reach the singleton
- Strips Mongo metadata (`_id`, `createdAt`, `updatedAt`, `__v`) via `stripSettingsMongoMetadata` so the admin UI can send the full settings object without tripping `.strict()`
- Merges partial booking-length updates with existing document values and rejects invalid ranges with the same structured error format
- Exports schema from `lib/validations/index.ts`

## Test plan
- [x] `pnpm test __tests__/validations/settings.test.ts __tests__/api/settings.test.ts` — 24/24 pass
- [x] `pnpm test:integration __tests__/integration/api/settings.test.ts` — 6/6 pass (179 total integration tests pass)
- [x] `pnpm check:types` — clean (12.06s)
- [x] `pnpm lint` — 0 errors

## Out of scope (deferred)
- Audit logging for settings mutations
- Rate limiting on the settings endpoint
- Granular per-field permission checks (all settings remain admin-only as a single gate)

Made with [Cursor](https://cursor.com)