### PR TITLE
Wire Zod validation into cabin/dining/experience API routes

### DIFF
--- a/__tests__/api/cabins.test.ts
+++ b/__tests__/api/cabins.test.ts
@@ -23,6 +23,7 @@ const mockCabinModel = {
   findById: jest.fn(),
   findByIdAndUpdate: jest.fn(),
   findByIdAndDelete: jest.fn(),
+  create: jest.fn(),
 };
 
 jest.mock('@/models/Cabin', () => ({
@@ -170,16 +171,18 @@ describe('/api/cabins', () => {
   });
 
   describe('POST /api/cabins', () => {
+    const validCabinPayload = {
+      name: 'Test Cabin',
+      description: 'A test cabin description here.',
+      capacity: 4,
+      price: 100,
+      image: 'https://example.com/cabin.jpg',
+    };
+
     it('should reject discount greater than price', async () => {
       const request = new NextRequest('http://localhost/api/cabins', {
         method: 'POST',
-        body: JSON.stringify({
-          name: 'Test Cabin',
-          description: 'A test cabin description here.',
-          capacity: 4,
-          price: 100,
-          discount: 150,
-        }),
+        body: JSON.stringify({ ...validCabinPayload, discount: 150 }),
       });
 
       const response = await POST(request);
@@ -187,7 +190,46 @@ describe('/api/cabins', () => {
 
       expect(response.status).toBe(400);
       expect(data.success).toBe(false);
-      expect(data.error).toContain('Discount');
+      expect(data.error).toBe('Validation failed');
+      expect(data.details.discount[0]).toContain('Discount');
+    });
+
+    it('should reject a missing required field', async () => {
+      const { image: _image, ...payload } = validCabinPayload;
+      const request = new NextRequest('http://localhost/api/cabins', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.details.image).toBeDefined();
+    });
+
+    it('should create a cabin with valid data', async () => {
+      const createdCabin = { ...mockCabinData, ...validCabinPayload };
+      mockCabinModel.create.mockResolvedValue(createdCabin);
+
+      const request = new NextRequest('http://localhost/api/cabins', {
+        method: 'POST',
+        body: JSON.stringify(validCabinPayload),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(mockCabinModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Test Cabin',
+          status: 'active',
+          discount: 0,
+        })
+      );
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
     });
   });
 

--- a/__tests__/api/cabins.test.ts
+++ b/__tests__/api/cabins.test.ts
@@ -231,6 +231,32 @@ describe('/api/cabins', () => {
       expect(response.status).toBe(201);
       expect(data.success).toBe(true);
     });
+
+    it('maps a Mongoose ValidationError to a 400 response', async () => {
+      const validationError = Object.assign(
+        new Error('Cabin validation failed'),
+        {
+          name: 'ValidationError',
+          errors: {
+            image: { message: 'Please provide a valid image URL' },
+          },
+        }
+      );
+      mockCabinModel.create.mockRejectedValue(validationError);
+
+      const request = new NextRequest('http://localhost/api/cabins', {
+        method: 'POST',
+        body: JSON.stringify(validCabinPayload),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details).toEqual(validationError.errors);
+    });
   });
 
   describe('PUT /api/cabins', () => {

--- a/__tests__/api/dining.test.ts
+++ b/__tests__/api/dining.test.ts
@@ -248,6 +248,37 @@ describe('/api/dining', () => {
       expect(response.status).toBe(201);
       expect(data.success).toBe(true);
     });
+
+    it('maps a Mongoose ValidationError to a 400 response', async () => {
+      const validationError = Object.assign(
+        new Error('Dining validation failed'),
+        {
+          name: 'ValidationError',
+          errors: {
+            price: { message: 'Price must be positive' },
+          },
+        }
+      );
+      MockDining.mockImplementation(
+        () =>
+          ({
+            save: jest.fn().mockRejectedValue(validationError),
+          }) as any
+      );
+
+      const request = new NextRequest('http://localhost/api/dining', {
+        method: 'POST',
+        body: JSON.stringify(validDiningPayload),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details).toEqual(validationError.errors);
+    });
   });
 
   describe('PUT /api/dining', () => {

--- a/__tests__/api/dining.test.ts
+++ b/__tests__/api/dining.test.ts
@@ -189,19 +189,24 @@ describe('/api/dining', () => {
   });
 
   describe('POST /api/dining', () => {
+    const validDiningPayload = {
+      name: 'Test Item',
+      description: 'A test dining item description.',
+      type: 'menu',
+      mealType: 'breakfast',
+      category: 'regular',
+      price: 25,
+      servingTime: { start: '07:00', end: '10:30' },
+      maxPeople: 50,
+      image: 'https://example.com/test.jpg',
+    };
+
     it('should reject invalid serving time format', async () => {
       const request = new NextRequest('http://localhost/api/dining', {
         method: 'POST',
         body: JSON.stringify({
-          name: 'Test Item',
-          description: 'A test dining item description.',
-          type: 'menu',
-          mealType: 'breakfast',
-          category: 'regular',
-          price: 25,
+          ...validDiningPayload,
           servingTime: { start: '7:00 AM', end: '10:30 AM' },
-          maxPeople: 50,
-          image: 'https://example.com/test.jpg',
         }),
       });
 
@@ -210,6 +215,38 @@ describe('/api/dining', () => {
 
       expect(response.status).toBe(400);
       expect(data.success).toBe(false);
+    });
+
+    it('should reject an invalid type/mealType/category combination', async () => {
+      const request = new NextRequest('http://localhost/api/dining', {
+        method: 'POST',
+        body: JSON.stringify({
+          ...validDiningPayload,
+          type: 'breakfast',
+          mealType: 'vegetarian',
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.details.type).toBeDefined();
+      expect(data.details.mealType).toBeDefined();
+    });
+
+    it('should create a dining item with valid data', async () => {
+      const request = new NextRequest('http://localhost/api/dining', {
+        method: 'POST',
+        body: JSON.stringify(validDiningPayload),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
     });
   });
 

--- a/__tests__/api/experiences.test.ts
+++ b/__tests__/api/experiences.test.ts
@@ -215,6 +215,48 @@ describe('/api/experiences', () => {
         error: 'Failed to create experience',
       });
     });
+
+    it('maps a Mongoose ValidationError to a 400 response', async () => {
+      const validationError = Object.assign(
+        new Error('Experience validation failed'),
+        {
+          name: 'ValidationError',
+          errors: {
+            price: { message: 'Price cannot be negative' },
+          },
+        }
+      );
+      MockExperience.mockImplementation(
+        () =>
+          ({
+            save: jest.fn().mockRejectedValue(validationError),
+          }) as any
+      );
+
+      const request = new NextRequest('http://localhost/api/experiences', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Mountain Hiking Adventure',
+          price: 299,
+          duration: '4 hours',
+          difficulty: 'Moderate',
+          category: 'Adventure',
+          description: 'Experience the thrill of mountain hiking',
+          image: '/images/hiking.jpg',
+          includes: ['Guide', 'Equipment', 'Snacks'],
+          available: ['2024-06-01', '2024-06-15'],
+          ctaText: 'Book Now',
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Validation failed');
+      expect(data.details).toEqual(validationError.errors);
+    });
   });
 });
 

--- a/__tests__/api/experiences.test.ts
+++ b/__tests__/api/experiences.test.ts
@@ -142,6 +142,7 @@ describe('/api/experiences', () => {
         available: ['2024-06-01', '2024-06-15'],
         ctaText: 'Book Now',
         isPopular: true,
+        reviewCount: 0,
       });
       expect(mockSave).toHaveBeenCalledTimes(1);
       expect(response.status).toBe(201);
@@ -150,6 +151,19 @@ describe('/api/experiences', () => {
         name: mockExperienceData.name,
         price: mockExperienceData.price,
       });
+    });
+
+    it('should reject an incomplete payload with a validation error', async () => {
+      const request = new NextRequest('http://localhost/api/experiences', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Test Experience' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
     });
 
     it('should handle creation errors', async () => {
@@ -162,7 +176,18 @@ describe('/api/experiences', () => {
 
       const request = new NextRequest('http://localhost/api/experiences', {
         method: 'POST',
-        body: JSON.stringify({ name: 'Test Experience' }),
+        body: JSON.stringify({
+          name: 'Mountain Hiking Adventure',
+          price: 299,
+          duration: '4 hours',
+          difficulty: 'Moderate',
+          category: 'Adventure',
+          description: 'Experience the thrill of mountain hiking',
+          image: '/images/hiking.jpg',
+          includes: ['Guide', 'Equipment', 'Snacks'],
+          available: ['2024-06-01', '2024-06-15'],
+          ctaText: 'Book Now',
+        }),
       });
 
       const response = await POST(request);

--- a/__tests__/api/experiences.test.ts
+++ b/__tests__/api/experiences.test.ts
@@ -241,7 +241,7 @@ describe('/api/experiences/[id]', () => {
         '507f1f77bcf86cd799439011'
       );
       expect(response.status).toBe(200);
-      expect(data).toEqual(mockExperienceData);
+      expect(data).toEqual({ success: true, data: mockExperienceData });
     });
 
     it('should return 404 when experience not found', async () => {
@@ -256,7 +256,7 @@ describe('/api/experiences/[id]', () => {
       const data = await response.json();
 
       expect(response.status).toBe(404);
-      expect(data).toEqual({ error: 'Experience not found' });
+      expect(data).toEqual({ success: false, error: 'Experience not found' });
     });
 
     it('should handle database errors', async () => {
@@ -273,7 +273,10 @@ describe('/api/experiences/[id]', () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data).toEqual({ error: 'Failed to fetch experience' });
+      expect(data).toEqual({
+        success: false,
+        error: 'Failed to fetch experience',
+      });
     });
   });
 
@@ -303,7 +306,39 @@ describe('/api/experiences/[id]', () => {
         { new: true, runValidators: true }
       );
       expect(response.status).toBe(200);
-      expect(data).toEqual(updatedData);
+      expect(data).toEqual({ success: true, data: updatedData });
+    });
+
+    it('should accept a full round-tripped payload including _id', async () => {
+      const updatedData = { ...mockExperienceData, name: 'Updated Adventure' };
+      MockExperience.findByIdAndUpdate = jest
+        .fn()
+        .mockResolvedValue(updatedData);
+
+      const request = new NextRequest(
+        'http://localhost/api/experiences/507f1f77bcf86cd799439011',
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            ...mockExperienceData,
+            name: 'Updated Adventure',
+          }),
+        }
+      );
+      const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+
+      const response = await PUT(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true, data: updatedData });
+      // _id/createdAt/updatedAt from the round-tripped object must not reach
+      // findByIdAndUpdate as part of the update payload.
+      const [, updatePayload] =
+        MockExperience.findByIdAndUpdate.mock.calls.at(-1)!;
+      expect(updatePayload).not.toHaveProperty('_id');
+      expect(updatePayload).not.toHaveProperty('createdAt');
+      expect(updatePayload).not.toHaveProperty('updatedAt');
     });
 
     it('should return 404 when updating non-existent experience', async () => {
@@ -322,7 +357,7 @@ describe('/api/experiences/[id]', () => {
       const data = await response.json();
 
       expect(response.status).toBe(404);
-      expect(data).toEqual({ error: 'Experience not found' });
+      expect(data).toEqual({ success: false, error: 'Experience not found' });
     });
 
     it('should handle update errors', async () => {
@@ -343,7 +378,10 @@ describe('/api/experiences/[id]', () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data).toEqual({ error: 'Failed to update experience' });
+      expect(data).toEqual({
+        success: false,
+        error: 'Failed to update experience',
+      });
     });
 
     it('should handle invalid JSON in PUT request', async () => {
@@ -360,7 +398,10 @@ describe('/api/experiences/[id]', () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data).toEqual({ error: 'Failed to update experience' });
+      expect(data).toEqual({
+        success: false,
+        error: 'Failed to update experience',
+      });
     });
   });
 
@@ -386,7 +427,11 @@ describe('/api/experiences/[id]', () => {
         '507f1f77bcf86cd799439011'
       );
       expect(response.status).toBe(200);
-      expect(data).toEqual({ message: 'Experience deleted' });
+      expect(data).toEqual({
+        success: true,
+        data: null,
+        message: 'Experience deleted successfully',
+      });
     });
 
     it('should return 404 when deleting non-existent experience', async () => {
@@ -404,7 +449,7 @@ describe('/api/experiences/[id]', () => {
       const data = await response.json();
 
       expect(response.status).toBe(404);
-      expect(data).toEqual({ error: 'Experience not found' });
+      expect(data).toEqual({ success: false, error: 'Experience not found' });
     });
 
     it('should handle deletion errors', async () => {
@@ -424,7 +469,10 @@ describe('/api/experiences/[id]', () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data).toEqual({ error: 'Failed to delete experience' });
+      expect(data).toEqual({
+        success: false,
+        error: 'Failed to delete experience',
+      });
     });
   });
 });

--- a/__tests__/integration/api/cabins.test.ts
+++ b/__tests__/integration/api/cabins.test.ts
@@ -204,6 +204,40 @@ describe('Cabins API Routes', () => {
       expect(response.status).toBe(200);
       expect(body.data.discount).toBe(50);
     });
+
+    it('rejects a price-only update that drops below the stored discount', async () => {
+      const cabin = await Cabin.create(
+        validCabinPayload({ price: 100, discount: 80 })
+      );
+
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'PUT',
+        body: { _id: cabin._id.toString(), price: 50 },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('accepts a price-only update that stays above the stored discount', async () => {
+      const cabin = await Cabin.create(
+        validCabinPayload({ price: 100, discount: 80 })
+      );
+
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'PUT',
+        body: { _id: cabin._id.toString(), price: 200 },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.price).toBe(200);
+    });
   });
 
   describe('GET /api/cabins/[id]', () => {
@@ -266,6 +300,24 @@ describe('Cabins API Routes', () => {
       const request = createRequest(
         `http://localhost:3000/api/cabins/${cabin._id}`,
         { method: 'PUT', body: { discount: 150 } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: cabin._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('rejects a price-only update that drops below the stored discount', async () => {
+      const cabin = await Cabin.create(
+        validCabinPayload({ price: 100, discount: 80 })
+      );
+
+      const request = createRequest(
+        `http://localhost:3000/api/cabins/${cabin._id}`,
+        { method: 'PUT', body: { price: 50 } }
       );
       const response = await updateById(request, {
         params: Promise.resolve({ id: cabin._id.toString() }),

--- a/__tests__/integration/api/cabins.test.ts
+++ b/__tests__/integration/api/cabins.test.ts
@@ -1,0 +1,233 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/mongodb', () => jest.fn().mockResolvedValue(undefined));
+
+import { GET, POST, PUT } from '@/app/api/cabins/route';
+import { GET as getById, PUT as updateById } from '@/app/api/cabins/[id]/route';
+import Cabin from '@/models/Cabin';
+
+function createRequest(url: string, options?: { method?: string; body?: any }) {
+  const init: RequestInit = { method: options?.method || 'GET' };
+  if (options?.body) {
+    init.body = JSON.stringify(options.body);
+    init.headers = { 'Content-Type': 'application/json' };
+  }
+  return new NextRequest(new URL(url, 'http://localhost:3000'), init);
+}
+
+function validCabinPayload(overrides: Record<string, any> = {}) {
+  return {
+    name: 'Lakeside Cabin',
+    description: 'A beautiful cabin with stunning lake views and comfort.',
+    capacity: 4,
+    price: 200,
+    image: 'https://example.com/cabin.jpg',
+    ...overrides,
+  };
+}
+
+describe('Cabins API Routes', () => {
+  describe('GET /api/cabins', () => {
+    it('returns cabins from the database', async () => {
+      await Cabin.create(validCabinPayload());
+
+      const request = createRequest('http://localhost:3000/api/cabins');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data).toHaveLength(1);
+    });
+  });
+
+  describe('POST /api/cabins', () => {
+    it('creates a cabin with a valid payload and applies schema defaults', async () => {
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'POST',
+        body: validCabinPayload(),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('active');
+      expect(body.data.discount).toBe(0);
+
+      const stored = await Cabin.findById(body.data._id);
+      expect(stored).not.toBeNull();
+    });
+
+    it('rejects a payload missing required fields', async () => {
+      const { image: _image, ...payload } = validCabinPayload();
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'POST',
+        body: payload,
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.details.image).toBeDefined();
+
+      const count = await Cabin.countDocuments();
+      expect(count).toBe(0);
+    });
+
+    it('rejects a discount greater than or equal to the price', async () => {
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'POST',
+        body: validCabinPayload({ discount: 200 }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.details.discount[0]).toContain('Discount');
+    });
+
+    it('rejects an invalid status value', async () => {
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'POST',
+        body: validCabinPayload({ status: 'closed' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('persists optional fields added to reconcile with the Cabin model', async () => {
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'POST',
+        body: validCabinPayload({
+          status: 'maintenance',
+          minNights: 2,
+          extraGuestFee: 15,
+          images: ['https://example.com/gallery1.jpg'],
+          bedrooms: 2,
+          bathrooms: 1,
+          size: 750,
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.data.status).toBe('maintenance');
+      expect(body.data.minNights).toBe(2);
+      expect(body.data.extraGuestFee).toBe(15);
+      expect(body.data.images).toEqual(['https://example.com/gallery1.jpg']);
+    });
+  });
+
+  describe('PUT /api/cabins', () => {
+    it('updates a cabin without resetting fields absent from the payload', async () => {
+      const cabin = await Cabin.create(
+        validCabinPayload({ status: 'maintenance', discount: 50 })
+      );
+
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'PUT',
+        body: { _id: cabin._id.toString(), name: 'Renamed Cabin' },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.name).toBe('Renamed Cabin');
+      expect(body.data.status).toBe('maintenance');
+      expect(body.data.discount).toBe(50);
+    });
+
+    it('rejects an update with discount above the (possibly updated) price', async () => {
+      const cabin = await Cabin.create(validCabinPayload());
+
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'PUT',
+        body: { _id: cabin._id.toString(), price: 100, discount: 150 },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('returns 404 when the cabin does not exist', async () => {
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'PUT',
+        body: { _id: '507f1f77bcf86cd799439011', name: 'Ghost Cabin' },
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/cabins/[id]', () => {
+    it('returns a cabin by id', async () => {
+      const cabin = await Cabin.create(validCabinPayload());
+
+      const request = createRequest(
+        `http://localhost:3000/api/cabins/${cabin._id}`
+      );
+      const response = await getById(request, {
+        params: Promise.resolve({ id: cabin._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.name).toBe('Lakeside Cabin');
+    });
+  });
+
+  describe('PUT /api/cabins/[id]', () => {
+    it('updates a cabin by id without resetting absent fields', async () => {
+      const cabin = await Cabin.create(
+        validCabinPayload({ amenities: ['wifi'], extraGuestFee: 20 })
+      );
+
+      const request = createRequest(
+        `http://localhost:3000/api/cabins/${cabin._id}`,
+        { method: 'PUT', body: { price: 250 } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: cabin._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.price).toBe(250);
+      expect(body.data.amenities).toEqual(['wifi']);
+      expect(body.data.extraGuestFee).toBe(20);
+    });
+
+    it('rejects an invalid image URL on update', async () => {
+      const cabin = await Cabin.create(validCabinPayload());
+
+      const request = createRequest(
+        `http://localhost:3000/api/cabins/${cabin._id}`,
+        { method: 'PUT', body: { image: 'not-a-url' } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: cabin._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+  });
+});

--- a/__tests__/integration/api/cabins.test.ts
+++ b/__tests__/integration/api/cabins.test.ts
@@ -174,6 +174,36 @@ describe('Cabins API Routes', () => {
       const response = await PUT(request);
       expect(response.status).toBe(404);
     });
+
+    it('rejects a discount-only update that exceeds the stored price', async () => {
+      const cabin = await Cabin.create(validCabinPayload({ price: 100 }));
+
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'PUT',
+        body: { _id: cabin._id.toString(), discount: 150 },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('accepts a discount-only update within the stored price', async () => {
+      const cabin = await Cabin.create(validCabinPayload({ price: 100 }));
+
+      const request = createRequest('http://localhost:3000/api/cabins', {
+        method: 'PUT',
+        body: { _id: cabin._id.toString(), discount: 50 },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.discount).toBe(50);
+    });
   });
 
   describe('GET /api/cabins/[id]', () => {
@@ -220,6 +250,22 @@ describe('Cabins API Routes', () => {
       const request = createRequest(
         `http://localhost:3000/api/cabins/${cabin._id}`,
         { method: 'PUT', body: { image: 'not-a-url' } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: cabin._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('rejects a discount-only update that exceeds the stored price', async () => {
+      const cabin = await Cabin.create(validCabinPayload({ price: 100 }));
+
+      const request = createRequest(
+        `http://localhost:3000/api/cabins/${cabin._id}`,
+        { method: 'PUT', body: { discount: 150 } }
       );
       const response = await updateById(request, {
         params: Promise.resolve({ id: cabin._id.toString() }),

--- a/__tests__/integration/api/cabins.test.ts
+++ b/__tests__/integration/api/cabins.test.ts
@@ -310,6 +310,22 @@ describe('Cabins API Routes', () => {
       expect(body.success).toBe(false);
     });
 
+    it('accepts a discount-only update within the stored price', async () => {
+      const cabin = await Cabin.create(validCabinPayload({ price: 100 }));
+
+      const request = createRequest(
+        `http://localhost:3000/api/cabins/${cabin._id}`,
+        { method: 'PUT', body: { discount: 50 } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: cabin._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.discount).toBe(50);
+    });
+
     it('rejects a price-only update that drops below the stored discount', async () => {
       const cabin = await Cabin.create(
         validCabinPayload({ price: 100, discount: 80 })
@@ -326,6 +342,36 @@ describe('Cabins API Routes', () => {
 
       expect(response.status).toBe(400);
       expect(body.success).toBe(false);
+    });
+
+    it('accepts a price-only update that stays above the stored discount', async () => {
+      const cabin = await Cabin.create(
+        validCabinPayload({ price: 100, discount: 80 })
+      );
+
+      const request = createRequest(
+        `http://localhost:3000/api/cabins/${cabin._id}`,
+        { method: 'PUT', body: { price: 200 } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: cabin._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.price).toBe(200);
+    });
+
+    it('returns 404 when updating a non-existent cabin', async () => {
+      const request = createRequest(
+        'http://localhost:3000/api/cabins/507f1f77bcf86cd799439011',
+        { method: 'PUT', body: { name: 'Ghost Cabin' } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: '507f1f77bcf86cd799439011' }),
+      });
+
+      expect(response.status).toBe(404);
     });
   });
 });

--- a/__tests__/integration/api/dining.test.ts
+++ b/__tests__/integration/api/dining.test.ts
@@ -1,0 +1,205 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/mongodb', () => jest.fn().mockResolvedValue(undefined));
+
+import { GET, POST, PUT } from '@/app/api/dining/route';
+import { GET as getById, PUT as updateById } from '@/app/api/dining/[id]/route';
+import Dining from '@/models/Dining';
+
+function createRequest(url: string, options?: { method?: string; body?: any }) {
+  const init: RequestInit = { method: options?.method || 'GET' };
+  if (options?.body) {
+    init.body = JSON.stringify(options.body);
+    init.headers = { 'Content-Type': 'application/json' };
+  }
+  return new NextRequest(new URL(url, 'http://localhost:3000'), init);
+}
+
+function validDiningPayload(overrides: Record<string, any> = {}) {
+  return {
+    name: 'Continental Breakfast',
+    description:
+      'A delicious continental breakfast with fresh pastries and coffee.',
+    type: 'menu',
+    mealType: 'breakfast',
+    category: 'regular',
+    price: 25,
+    servingTime: { start: '07:00', end: '10:30' },
+    maxPeople: 50,
+    image: 'https://example.com/breakfast.jpg',
+    ...overrides,
+  };
+}
+
+describe('Dining API Routes', () => {
+  describe('GET /api/dining', () => {
+    it('returns dining items from the database', async () => {
+      await Dining.create(validDiningPayload());
+
+      const request = createRequest('http://localhost:3000/api/dining');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data).toHaveLength(1);
+    });
+  });
+
+  describe('POST /api/dining', () => {
+    it('creates a dining item with a valid payload and applies schema defaults', async () => {
+      const request = createRequest('http://localhost:3000/api/dining', {
+        method: 'POST',
+        body: validDiningPayload(),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data.isAvailable).toBe(true);
+      expect(body.data.minPeople).toBe(1);
+
+      const stored = await Dining.findById(body.data._id);
+      expect(stored).not.toBeNull();
+    });
+
+    it('rejects a payload with a type/mealType/category that does not match the model enums', async () => {
+      const request = createRequest('http://localhost:3000/api/dining', {
+        method: 'POST',
+        body: validDiningPayload({ type: 'breakfast', mealType: 'vegetarian' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.details.type).toBeDefined();
+      expect(body.details.mealType).toBeDefined();
+
+      const count = await Dining.countDocuments();
+      expect(count).toBe(0);
+    });
+
+    it('rejects an invalid serving time format', async () => {
+      const request = createRequest('http://localhost:3000/api/dining', {
+        method: 'POST',
+        body: validDiningPayload({
+          servingTime: { start: '7:00 AM', end: '10:00 AM' },
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('persists beverages and dietary options added to reconcile with the Dining model', async () => {
+      const request = createRequest('http://localhost:3000/api/dining', {
+        method: 'POST',
+        body: validDiningPayload({
+          dietary: ['vegetarian', 'gluten-free'],
+          beverages: [{ name: 'House IPA', category: 'craft-beer', price: 8 }],
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.data.dietary).toEqual(['vegetarian', 'gluten-free']);
+      expect(body.data.beverages).toHaveLength(1);
+      expect(body.data.beverages[0].name).toBe('House IPA');
+    });
+  });
+
+  describe('PUT /api/dining', () => {
+    it('updates a dining item without resetting fields absent from the payload', async () => {
+      const dining = await Dining.create(
+        validDiningPayload({ isPopular: true, minPeople: 3 })
+      );
+
+      const request = createRequest('http://localhost:3000/api/dining', {
+        method: 'PUT',
+        body: { _id: dining._id.toString(), price: 30 },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.price).toBe(30);
+      expect(body.data.isPopular).toBe(true);
+      expect(body.data.minPeople).toBe(3);
+    });
+
+    it('returns 404 when the dining item does not exist', async () => {
+      const request = createRequest('http://localhost:3000/api/dining', {
+        method: 'PUT',
+        body: { _id: '507f1f77bcf86cd799439011', price: 30 },
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/dining/[id]', () => {
+    it('returns a dining item by id', async () => {
+      const dining = await Dining.create(validDiningPayload());
+
+      const request = createRequest(
+        `http://localhost:3000/api/dining/${dining._id}`
+      );
+      const response = await getById(request, {
+        params: Promise.resolve({ id: dining._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.name).toBe('Continental Breakfast');
+    });
+  });
+
+  describe('PUT /api/dining/[id]', () => {
+    it('updates a dining item by id without resetting absent fields', async () => {
+      const dining = await Dining.create(
+        validDiningPayload({ allergens: ['gluten'], isAvailable: false })
+      );
+
+      const request = createRequest(
+        `http://localhost:3000/api/dining/${dining._id}`,
+        { method: 'PUT', body: { price: 40 } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: dining._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.price).toBe(40);
+      expect(body.data.allergens).toEqual(['gluten']);
+      expect(body.data.isAvailable).toBe(false);
+    });
+
+    it('rejects an invalid category on update', async () => {
+      const dining = await Dining.create(validDiningPayload());
+
+      const request = createRequest(
+        `http://localhost:3000/api/dining/${dining._id}`,
+        { method: 'PUT', body: { category: 'invalid' } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: dining._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+  });
+});

--- a/__tests__/integration/api/experiences.test.ts
+++ b/__tests__/integration/api/experiences.test.ts
@@ -1,0 +1,187 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/mongodb', () => jest.fn().mockResolvedValue(undefined));
+
+import { GET, POST } from '@/app/api/experiences/route';
+import {
+  GET as getById,
+  PUT as updateById,
+} from '@/app/api/experiences/[id]/route';
+import { Experience } from '@/models/Experience';
+
+function createRequest(url: string, options?: { method?: string; body?: any }) {
+  const init: RequestInit = { method: options?.method || 'GET' };
+  if (options?.body) {
+    init.body = JSON.stringify(options.body);
+    init.headers = { 'Content-Type': 'application/json' };
+  }
+  return new NextRequest(new URL(url, 'http://localhost:3000'), init);
+}
+
+function validExperiencePayload(overrides: Record<string, any> = {}) {
+  return {
+    name: 'Mountain Hiking Tour',
+    description: 'An exciting hiking tour through scenic mountain trails.',
+    duration: '4 hours',
+    price: 75,
+    difficulty: 'Moderate',
+    category: 'Outdoor',
+    image: 'https://example.com/tour.jpg',
+    includes: ['Guide', 'Water'],
+    available: ['Weekends', 'Weekdays'],
+    ctaText: 'Book Now',
+    ...overrides,
+  };
+}
+
+// Mongoose collections are cleared after every test (see jest.setup.node.ts),
+// but the model registry keeps a reference to the same connection.
+afterEach(async () => {
+  await Experience.deleteMany({});
+});
+
+describe('Experiences API Routes', () => {
+  describe('GET /api/experiences', () => {
+    it('returns experiences from the database', async () => {
+      await Experience.create(validExperiencePayload());
+
+      const request = createRequest('http://localhost:3000/api/experiences');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data).toHaveLength(1);
+    });
+  });
+
+  describe('POST /api/experiences', () => {
+    it('creates an experience with a valid payload and applies schema defaults', async () => {
+      const request = createRequest('http://localhost:3000/api/experiences', {
+        method: 'POST',
+        body: validExperiencePayload(),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data.isPopular).toBe(false);
+      expect(body.data.reviewCount).toBe(0);
+
+      const stored = await Experience.findById(body.data._id);
+      expect(stored).not.toBeNull();
+    });
+
+    it('rejects a payload missing required fields', async () => {
+      const { ctaText: _ctaText, ...payload } = validExperiencePayload();
+      const request = createRequest('http://localhost:3000/api/experiences', {
+        method: 'POST',
+        body: payload,
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+
+      const count = await Experience.countDocuments();
+      expect(count).toBe(0);
+    });
+
+    it('rejects an invalid difficulty value', async () => {
+      const request = createRequest('http://localhost:3000/api/experiences', {
+        method: 'POST',
+        body: validExperiencePayload({ difficulty: 'Extreme' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('rejects unknown legacy keys', async () => {
+      const request = createRequest('http://localhost:3000/api/experiences', {
+        method: 'POST',
+        body: { ...validExperiencePayload(), included: ['Legacy key'] },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe('GET /api/experiences/[id]', () => {
+    it('returns an experience by id', async () => {
+      const experience = await Experience.create(validExperiencePayload());
+
+      const request = createRequest(
+        `http://localhost:3000/api/experiences/${experience._id}`
+      );
+      const response = await getById(request, {
+        params: Promise.resolve({ id: experience._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.name).toBe('Mountain Hiking Tour');
+    });
+  });
+
+  describe('PUT /api/experiences/[id]', () => {
+    it('updates an experience without resetting fields absent from the payload', async () => {
+      const experience = await Experience.create(
+        validExperiencePayload({ isPopular: true, reviewCount: 12 })
+      );
+
+      const request = createRequest(
+        `http://localhost:3000/api/experiences/${experience._id}`,
+        { method: 'PUT', body: { price: 100 } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: experience._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.price).toBe(100);
+      expect(body.isPopular).toBe(true);
+      expect(body.reviewCount).toBe(12);
+    });
+
+    it('rejects an invalid difficulty value on update', async () => {
+      const experience = await Experience.create(validExperiencePayload());
+
+      const request = createRequest(
+        `http://localhost:3000/api/experiences/${experience._id}`,
+        { method: 'PUT', body: { difficulty: 'Extreme' } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: experience._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+
+    it('returns 404 when the experience does not exist', async () => {
+      const request = createRequest(
+        'http://localhost:3000/api/experiences/507f1f77bcf86cd799439011',
+        { method: 'PUT', body: { price: 100 } }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: '507f1f77bcf86cd799439011' }),
+      });
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/__tests__/integration/api/experiences.test.ts
+++ b/__tests__/integration/api/experiences.test.ts
@@ -104,7 +104,7 @@ describe('Experiences API Routes', () => {
       expect(body.success).toBe(false);
     });
 
-    it('rejects unknown legacy keys', async () => {
+    it('silently strips unknown legacy keys', async () => {
       const request = createRequest('http://localhost:3000/api/experiences', {
         method: 'POST',
         body: { ...validExperiencePayload(), included: ['Legacy key'] },
@@ -113,8 +113,9 @@ describe('Experiences API Routes', () => {
       const response = await POST(request);
       const body = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(body.success).toBe(false);
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.data).not.toHaveProperty('included');
     });
   });
 
@@ -131,7 +132,8 @@ describe('Experiences API Routes', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body.name).toBe('Mountain Hiking Tour');
+      expect(body.success).toBe(true);
+      expect(body.data.name).toBe('Mountain Hiking Tour');
     });
   });
 
@@ -151,9 +153,34 @@ describe('Experiences API Routes', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body.price).toBe(100);
-      expect(body.isPopular).toBe(true);
-      expect(body.reviewCount).toBe(12);
+      expect(body.success).toBe(true);
+      expect(body.data.price).toBe(100);
+      expect(body.data.isPopular).toBe(true);
+      expect(body.data.reviewCount).toBe(12);
+    });
+
+    it('accepts a full round-tripped payload including _id, createdAt, updatedAt', async () => {
+      const experience = await Experience.create(validExperiencePayload());
+
+      const request = createRequest(
+        `http://localhost:3000/api/experiences/${experience._id}`,
+        {
+          method: 'PUT',
+          body: {
+            ...experience.toObject(),
+            _id: experience._id.toString(),
+            name: 'Updated via round trip',
+          },
+        }
+      );
+      const response = await updateById(request, {
+        params: Promise.resolve({ id: experience._id.toString() }),
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.name).toBe('Updated via round trip');
     });
 
     it('rejects an invalid difficulty value on update', async () => {

--- a/__tests__/integration/models/cabin.test.ts
+++ b/__tests__/integration/models/cabin.test.ts
@@ -143,6 +143,63 @@ describe('Cabin Model', () => {
     });
   });
 
+  describe('Discount Validation', () => {
+    it('rejects a discount >= price on create (document context)', async () => {
+      await expect(
+        Cabin.create(createCabinData({ price: 100, discount: 100 }))
+      ).rejects.toThrow(/Discount must be less than the cabin price/);
+    });
+
+    it('accepts a discount below price on create (document context)', async () => {
+      const cabin = await Cabin.create(
+        createCabinData({ price: 100, discount: 50 })
+      );
+      expect(cabin.discount).toBe(50);
+    });
+
+    it('rejects a findByIdAndUpdate with both price and discount when the combination is invalid (query context)', async () => {
+      const cabin = await Cabin.create(createCabinData({ price: 100 }));
+
+      await expect(
+        Cabin.findByIdAndUpdate(
+          cabin._id,
+          { price: 100, discount: 150 },
+          { runValidators: true }
+        )
+      ).rejects.toThrow(/Discount must be less than the cabin price/);
+    });
+
+    it('accepts a discount-only findByIdAndUpdate within the price sent in the same update (query context)', async () => {
+      const cabin = await Cabin.create(createCabinData({ price: 100 }));
+
+      const updated = await Cabin.findByIdAndUpdate(
+        cabin._id,
+        { price: 200, discount: 150 },
+        { new: true, runValidators: true }
+      );
+      expect(updated?.discount).toBe(150);
+    });
+
+    it('cannot see the stored price when only discount is in the update — the caller must pre-check it', async () => {
+      // Documents the query-context limitation described in models/Cabin.ts:
+      // `this` resolves to the Query, not the persisted document, so a
+      // discount-only update can't see the stored price here at all. The API
+      // routes (app/api/cabins/route.ts, app/api/cabins/[id]/route.ts)
+      // compensate by fetching the stored price and validating before
+      // calling findByIdAndUpdate. This update bypasses that route-level
+      // check by calling the model directly, so an invalid discount is not
+      // caught at this layer alone.
+      const cabin = await Cabin.create(createCabinData({ price: 100 }));
+
+      const updated = await Cabin.findByIdAndUpdate(
+        cabin._id,
+        { discount: 9999 },
+        { new: true, runValidators: true }
+      );
+      expect(updated?.discount).toBe(9999);
+    });
+  });
+
   describe('Virtuals', () => {
     it('calculates discountedPrice', async () => {
       const cabin = await Cabin.create(

--- a/__tests__/validations/cabin.test.ts
+++ b/__tests__/validations/cabin.test.ts
@@ -8,6 +8,7 @@ describe('Cabin Validation Schemas', () => {
         'A beautiful cabin with stunning lake views and modern amenities.',
       capacity: 4,
       price: 200,
+      image: 'https://example.com/cabin.jpg',
     };
 
     it('accepts valid cabin data', () => {
@@ -20,7 +21,10 @@ describe('Cabin Validation Schemas', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.discount).toBe(0);
-        expect(result.data.isAvailable).toBe(true);
+        expect(result.data.status).toBe('active');
+        expect(result.data.amenities).toEqual([]);
+        expect(result.data.images).toEqual([]);
+        expect(result.data.extraGuestFee).toBe(0);
       }
     });
 
@@ -50,14 +54,14 @@ describe('Cabin Validation Schemas', () => {
       }
     });
 
-    it('rejects description over 2000 characters', () => {
-      const cabin = { ...validCabin, description: 'A'.repeat(2001) };
+    it('rejects description over 1000 characters (matches Cabin model maxlength)', () => {
+      const cabin = { ...validCabin, description: 'A'.repeat(1001) };
       const result = createCabinSchema.safeParse(cabin);
       expect(result.success).toBe(false);
     });
 
-    it('accepts description at boundary (10 chars)', () => {
-      const cabin = { ...validCabin, description: 'A'.repeat(10) };
+    it('accepts description at boundary (1000 chars)', () => {
+      const cabin = { ...validCabin, description: 'A'.repeat(1000) };
       const result = createCabinSchema.safeParse(cabin);
       expect(result.success).toBe(true);
     });
@@ -127,10 +131,10 @@ describe('Cabin Validation Schemas', () => {
       expect(result.success).toBe(false);
     });
 
-    it('accepts valid image URL', () => {
-      const cabin = { ...validCabin, image: 'https://example.com/cabin.jpg' };
+    it('requires an image URL', () => {
+      const { image: _image, ...cabin } = validCabin;
       const result = createCabinSchema.safeParse(cabin);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
     it('rejects invalid image URL', () => {
@@ -154,6 +158,81 @@ describe('Cabin Validation Schemas', () => {
       if (result.success) {
         expect(result.data.amenities).toEqual([]);
       }
+    });
+
+    it('accepts a gallery of image URLs', () => {
+      const cabin = {
+        ...validCabin,
+        images: ['https://example.com/1.jpg', 'https://example.com/2.jpg'],
+      };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an invalid gallery image URL', () => {
+      const cabin = { ...validCabin, images: ['not-a-url'] };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts valid status values', () => {
+      (['active', 'maintenance', 'inactive'] as const).forEach(status => {
+        const result = createCabinSchema.safeParse({ ...validCabin, status });
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it('rejects invalid status value', () => {
+      const cabin = { ...validCabin, status: 'closed' };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts bedrooms, bathrooms, and size', () => {
+      const cabin = { ...validCabin, bedrooms: 2, bathrooms: 1, size: 800 };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects bedrooms less than 1', () => {
+      const cabin = { ...validCabin, bedrooms: 0 };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts minNights', () => {
+      const cabin = { ...validCabin, minNights: 2 };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects minNights less than 1', () => {
+      const cabin = { ...validCabin, minNights: 0 };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts extraGuestFee and defaults to 0', () => {
+      const withFee = createCabinSchema.safeParse({
+        ...validCabin,
+        extraGuestFee: 25,
+      });
+      expect(withFee.success).toBe(true);
+      if (withFee.success) {
+        expect(withFee.data.extraGuestFee).toBe(25);
+      }
+
+      const withoutFee = createCabinSchema.safeParse(validCabin);
+      expect(withoutFee.success).toBe(true);
+      if (withoutFee.success) {
+        expect(withoutFee.data.extraGuestFee).toBe(0);
+      }
+    });
+
+    it('rejects negative extraGuestFee', () => {
+      const cabin = { ...validCabin, extraGuestFee: -5 };
+      const result = createCabinSchema.safeParse(cabin);
+      expect(result.success).toBe(false);
     });
   });
 
@@ -215,12 +294,62 @@ describe('Cabin Validation Schemas', () => {
       expect(result.success).toBe(false);
     });
 
-    it('accepts isAvailable update', () => {
+    it('rejects description over 1000 characters on update (matches create limit)', () => {
       const result = updateCabinSchema.safeParse({
         _id: '65a1b2c3d4e5f6a7b8c9d0e1',
-        isAvailable: false,
+        description: 'A'.repeat(1001),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts status update', () => {
+      const result = updateCabinSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        status: 'maintenance',
       });
       expect(result.success).toBe(true);
+    });
+
+    it('rejects invalid status update', () => {
+      const result = updateCabinSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        status: 'closed',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts minNights and extraGuestFee updates', () => {
+      const result = updateCabinSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        minNights: 3,
+        extraGuestFee: 15,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts images gallery update', () => {
+      const result = updateCabinSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        images: ['https://example.com/new.jpg'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('does not fill in defaults for fields absent from the update payload', () => {
+      const result = updateCabinSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        name: 'Renamed Cabin',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // A partial update must not silently reset discount/status/amenities/
+        // images/extraGuestFee back to their create-time defaults.
+        expect('discount' in result.data).toBe(false);
+        expect('status' in result.data).toBe(false);
+        expect('amenities' in result.data).toBe(false);
+        expect('images' in result.data).toBe(false);
+        expect('extraGuestFee' in result.data).toBe(false);
+      }
     });
   });
 });

--- a/__tests__/validations/cabin.test.ts
+++ b/__tests__/validations/cabin.test.ts
@@ -1,4 +1,8 @@
-import { createCabinSchema, updateCabinSchema } from '@/lib/validations/cabin';
+import {
+  createCabinSchema,
+  isDiscountValid,
+  updateCabinSchema,
+} from '@/lib/validations/cabin';
 
 describe('Cabin Validation Schemas', () => {
   describe('createCabinSchema', () => {
@@ -350,6 +354,31 @@ describe('Cabin Validation Schemas', () => {
         expect('images' in result.data).toBe(false);
         expect('extraGuestFee' in result.data).toBe(false);
       }
+    });
+
+    it('strips $-operator and dotted keys from a valid update payload', () => {
+      const result = updateCabinSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        price: 250,
+        $set: { price: 1 },
+        'amenities.0': 'hacked',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect('$set' in result.data).toBe(false);
+        expect('amenities.0' in result.data).toBe(false);
+      }
+    });
+  });
+
+  describe('isDiscountValid', () => {
+    it('returns true when discount is less than price', () => {
+      expect(isDiscountValid(50, 200)).toBe(true);
+    });
+
+    it('returns false when discount equals or exceeds price', () => {
+      expect(isDiscountValid(200, 200)).toBe(false);
+      expect(isDiscountValid(250, 200)).toBe(false);
     });
   });
 });

--- a/__tests__/validations/dining.test.ts
+++ b/__tests__/validations/dining.test.ts
@@ -3,20 +3,13 @@ import {
   updateDiningSchema,
   diningTypeSchema,
   mealTypeSchema,
+  diningCategorySchema,
 } from '@/lib/validations/dining';
 
 describe('Dining Validation Schemas', () => {
   describe('diningTypeSchema', () => {
-    it('accepts valid dining types', () => {
-      const validTypes = [
-        'breakfast',
-        'lunch',
-        'dinner',
-        'snack',
-        'beverage',
-        'dessert',
-      ];
-      validTypes.forEach(type => {
+    it('accepts valid dining types (matches Dining model)', () => {
+      ['menu', 'experience'].forEach(type => {
         expect(diningTypeSchema.safeParse(type).success).toBe(true);
       });
     });
@@ -28,22 +21,29 @@ describe('Dining Validation Schemas', () => {
   });
 
   describe('mealTypeSchema', () => {
-    it('accepts valid meal types', () => {
-      const validTypes = [
-        'vegetarian',
-        'vegan',
-        'gluten-free',
-        'dairy-free',
-        'nut-free',
-        'regular',
-      ];
-      validTypes.forEach(type => {
+    it('accepts valid meal types (matches Dining model)', () => {
+      ['breakfast', 'lunch', 'dinner', 'all-day'].forEach(type => {
         expect(mealTypeSchema.safeParse(type).success).toBe(true);
       });
     });
 
     it('rejects invalid meal types', () => {
-      const result = mealTypeSchema.safeParse('keto');
+      const result = mealTypeSchema.safeParse('vegetarian');
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('diningCategorySchema', () => {
+    it('accepts valid categories (matches Dining model)', () => {
+      ['regular', 'craft-beer', 'wine', 'spirits', 'non-alcoholic'].forEach(
+        category => {
+          expect(diningCategorySchema.safeParse(category).success).toBe(true);
+        }
+      );
+    });
+
+    it('rejects invalid categories', () => {
+      const result = diningCategorySchema.safeParse('appetizer');
       expect(result.success).toBe(false);
     });
   });
@@ -53,9 +53,9 @@ describe('Dining Validation Schemas', () => {
       name: 'Continental Breakfast',
       description:
         'A delicious continental breakfast with fresh pastries and coffee.',
-      type: 'breakfast',
-      mealType: 'regular',
-      category: 'Main',
+      type: 'menu',
+      mealType: 'breakfast',
+      category: 'regular',
       price: 25,
       servingTime: {
         start: '07:00',
@@ -76,6 +76,8 @@ describe('Dining Validation Schemas', () => {
       if (result.success) {
         expect(result.data.isAvailable).toBe(true);
         expect(result.data.isPopular).toBe(false);
+        expect(result.data.minPeople).toBe(1);
+        expect(result.data.reviewCount).toBe(0);
       }
     });
 
@@ -115,8 +117,8 @@ describe('Dining Validation Schemas', () => {
       expect(result.success).toBe(false);
     });
 
-    it('rejects empty category', () => {
-      const dining = { ...validDining, category: '' };
+    it('rejects invalid category', () => {
+      const dining = { ...validDining, category: 'invalid' };
       const result = createDiningSchema.safeParse(dining);
       expect(result.success).toBe(false);
     });
@@ -178,10 +180,37 @@ describe('Dining Validation Schemas', () => {
       expect(result.success).toBe(false);
     });
 
+    it('accepts minPeople', () => {
+      const dining = { ...validDining, minPeople: 5 };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects minPeople less than 1', () => {
+      const dining = { ...validDining, minPeople: 0 };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(false);
+    });
+
     it('rejects invalid image URL', () => {
       const dining = { ...validDining, image: 'not-a-url' };
       const result = createDiningSchema.safeParse(dining);
       expect(result.success).toBe(false);
+    });
+
+    it('accepts a gallery of image URLs', () => {
+      const dining = {
+        ...validDining,
+        gallery: ['https://example.com/1.jpg', 'https://example.com/2.jpg'],
+      };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts subCategory', () => {
+      const dining = { ...validDining, subCategory: 'IPA' };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(true);
     });
 
     it('accepts ingredients array', () => {
@@ -202,22 +231,97 @@ describe('Dining Validation Schemas', () => {
       expect(result.success).toBe(true);
     });
 
-    it('accepts calories as positive integer', () => {
-      const dining = { ...validDining, calories: 500 };
+    it('accepts valid dietary options', () => {
+      const dining = {
+        ...validDining,
+        dietary: ['vegetarian', 'gluten-free'],
+      };
       const result = createDiningSchema.safeParse(dining);
       expect(result.success).toBe(true);
     });
 
-    it('accepts zero calories', () => {
-      const dining = { ...validDining, calories: 0 };
-      const result = createDiningSchema.safeParse(dining);
-      expect(result.success).toBe(true);
-    });
-
-    it('rejects negative calories', () => {
-      const dining = { ...validDining, calories: -100 };
+    it('rejects invalid dietary option', () => {
+      const dining = { ...validDining, dietary: ['low-carb'] };
       const result = createDiningSchema.safeParse(dining);
       expect(result.success).toBe(false);
+    });
+
+    it('accepts a valid beverages array', () => {
+      const dining = {
+        ...validDining,
+        beverages: [
+          {
+            name: 'House IPA',
+            description: 'Hoppy and citrusy',
+            price: 8,
+            alcoholContent: 6.5,
+            category: 'craft-beer',
+          },
+        ],
+      };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a beverage missing a required name', () => {
+      const dining = {
+        ...validDining,
+        beverages: [{ category: 'wine' }],
+      };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a beverage with an invalid category', () => {
+      const dining = {
+        ...validDining,
+        beverages: [{ name: 'Mystery Drink', category: 'invalid' }],
+      };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts includes, duration, and location (dining experience fields)', () => {
+      const dining = {
+        ...validDining,
+        type: 'experience',
+        includes: ['Guide', 'Tasting flight'],
+        duration: '2 hours',
+        location: 'Vineyard terrace',
+      };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts specialRequirements, seasonality, and tags', () => {
+      const dining = {
+        ...validDining,
+        specialRequirements: ['Reservation required'],
+        seasonality: 'Summer only',
+        tags: ['popular', 'outdoor'],
+      };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(true);
+    });
+
+    it('validates rating range', () => {
+      expect(
+        createDiningSchema.safeParse({ ...validDining, rating: 4.5 }).success
+      ).toBe(true);
+      expect(
+        createDiningSchema.safeParse({ ...validDining, rating: 5.1 }).success
+      ).toBe(false);
+    });
+
+    it('validates reviewCount as non-negative integer', () => {
+      expect(
+        createDiningSchema.safeParse({ ...validDining, reviewCount: 12 })
+          .success
+      ).toBe(true);
+      expect(
+        createDiningSchema.safeParse({ ...validDining, reviewCount: -1 })
+          .success
+      ).toBe(false);
     });
 
     it('accepts isPopular true', () => {
@@ -226,6 +330,17 @@ describe('Dining Validation Schemas', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.isPopular).toBe(true);
+      }
+    });
+
+    it('does not accept a calories field that does not exist on the model', () => {
+      const dining = { ...validDining, calories: 500 };
+      const result = createDiningSchema.safeParse(dining);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(
+          (result.data as Record<string, unknown>).calories
+        ).toBeUndefined();
       }
     });
   });
@@ -263,6 +378,14 @@ describe('Dining Validation Schemas', () => {
       expect(result.success).toBe(false);
     });
 
+    it('validates category on update', () => {
+      const result = updateDiningSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        category: 'invalid',
+      });
+      expect(result.success).toBe(false);
+    });
+
     it('validates serving time format on update', () => {
       const result = updateDiningSchema.safeParse({
         _id: '65a1b2c3d4e5f6a7b8c9d0e1',
@@ -296,6 +419,30 @@ describe('Dining Validation Schemas', () => {
         allergens: ['peanuts'],
       });
       expect(result.success).toBe(true);
+    });
+
+    it('accepts beverages update', () => {
+      const result = updateDiningSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        beverages: [{ name: 'Merlot', category: 'wine' }],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('does not fill in defaults for fields absent from the update payload', () => {
+      const result = updateDiningSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        name: 'Renamed Item',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // A partial update must not silently reset minPeople/isPopular/
+        // isAvailable/reviewCount back to their create-time defaults.
+        expect('minPeople' in result.data).toBe(false);
+        expect('isPopular' in result.data).toBe(false);
+        expect('isAvailable' in result.data).toBe(false);
+        expect('reviewCount' in result.data).toBe(false);
+      }
     });
   });
 });

--- a/__tests__/validations/dining.test.ts
+++ b/__tests__/validations/dining.test.ts
@@ -444,5 +444,19 @@ describe('Dining Validation Schemas', () => {
         expect('reviewCount' in result.data).toBe(false);
       }
     });
+
+    it('strips $-operator and dotted keys from a valid update payload', () => {
+      const result = updateDiningSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        name: 'Renamed Item',
+        $set: { price: 1 },
+        'tags.0': 'hacked',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect('$set' in result.data).toBe(false);
+        expect('tags.0' in result.data).toBe(false);
+      }
+    });
   });
 });

--- a/__tests__/validations/experience.test.ts
+++ b/__tests__/validations/experience.test.ts
@@ -68,13 +68,16 @@ describe('Experience Validation Schemas', () => {
       ).toBe(false);
     });
 
-    it('rejects unknown legacy keys', () => {
+    it('silently strips unknown legacy keys', () => {
       const result = createExperienceSchema.safeParse({
         ...validExperience,
         included: ['Legacy key'],
       });
 
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect('included' in result.data).toBe(false);
+      }
     });
 
     it('rejects missing required fields', () => {
@@ -116,8 +119,24 @@ describe('Experience Validation Schemas', () => {
   });
 
   describe('updateExperienceSchema', () => {
+    it('requires _id field', () => {
+      const result = updateExperienceSchema.safeParse({});
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('_id');
+      }
+    });
+
+    it('accepts valid update with only _id', () => {
+      const result = updateExperienceSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+      });
+      expect(result.success).toBe(true);
+    });
+
     it('accepts partial updates', () => {
       const result = updateExperienceSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
         name: 'Updated Tour Name',
         price: 100,
       });
@@ -125,29 +144,64 @@ describe('Experience Validation Schemas', () => {
       expect(result.success).toBe(true);
     });
 
-    it('accepts empty updates', () => {
-      const result = updateExperienceSchema.safeParse({});
-      expect(result.success).toBe(true);
-    });
-
     it('rejects invalid difficulty on update', () => {
       const result = updateExperienceSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
         difficulty: 'expert',
       });
 
       expect(result.success).toBe(false);
     });
 
-    it('rejects unknown keys on update', () => {
+    it('silently strips unknown keys on update', () => {
       const result = updateExperienceSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
         isFeatured: true,
       });
 
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect('isFeatured' in result.data).toBe(false);
+      }
+    });
+
+    it('accepts a full round-tripped experience object (as the edit UI sends it)', () => {
+      // The Experiences admin UI fetches an experience, lets the user edit
+      // it, then PUTs the whole object back — including _id, createdAt, and
+      // updatedAt. These aren't schema fields and must be silently dropped
+      // rather than causing the whole update to be rejected.
+      const result = updateExperienceSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        name: 'Updated Tour Name',
+        price: 100,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect('createdAt' in result.data).toBe(false);
+        expect('updatedAt' in result.data).toBe(false);
+      }
+    });
+
+    it('strips $-operator and dotted keys from a valid update payload', () => {
+      const result = updateExperienceSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
+        name: 'Updated Tour Name',
+        $set: { price: 1 },
+        'tags.0': 'hacked',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect('$set' in result.data).toBe(false);
+        expect('tags.0' in result.data).toBe(false);
+      }
     });
 
     it('does not fill in defaults for fields absent from the update payload', () => {
       const result = updateExperienceSchema.safeParse({
+        _id: '65a1b2c3d4e5f6a7b8c9d0e1',
         name: 'Renamed Tour',
       });
       expect(result.success).toBe(true);

--- a/__tests__/validations/experience.test.ts
+++ b/__tests__/validations/experience.test.ts
@@ -145,5 +145,18 @@ describe('Experience Validation Schemas', () => {
 
       expect(result.success).toBe(false);
     });
+
+    it('does not fill in defaults for fields absent from the update payload', () => {
+      const result = updateExperienceSchema.safeParse({
+        name: 'Renamed Tour',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // A partial update must not silently reset isPopular/reviewCount
+        // back to their create-time defaults.
+        expect('isPopular' in result.data).toBe(false);
+        expect('reviewCount' in result.data).toBe(false);
+      }
+    });
   });
 });

--- a/app/api/cabins/[id]/route.ts
+++ b/app/api/cabins/[id]/route.ts
@@ -1,5 +1,6 @@
-import { requireApiAuth, sanitizeUpdatePayload } from '@/lib/api-utils';
+import { createValidationErrorResponse, requireApiAuth } from '@/lib/api-utils';
 import connectDB from '@/lib/mongodb';
+import { updateCabinSchema } from '@/lib/validations';
 import { isMongooseValidationError } from '@/types/errors';
 import { NextRequest, NextResponse } from 'next/server';
 import { Cabin } from '../../../../models';
@@ -57,41 +58,17 @@ export async function PUT(
 
     const body = await request.json();
 
-    // Get the current cabin to validate discount vs price
-    const currentCabin = await Cabin.findById(id);
-    if (!currentCabin) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Cabin not found',
-        },
-        { status: 404 }
-      );
+    const validationResult = updateCabinSchema.safeParse({ ...body, _id: id });
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
     }
 
-    // Validate discount vs price
-    const newPrice = body.price !== undefined ? body.price : currentCabin.price;
-    const newDiscount =
-      body.discount !== undefined ? body.discount : currentCabin.discount;
+    const { _id: _validatedId, ...updateData } = validationResult.data;
 
-    if (newDiscount >= newPrice) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Discount cannot be greater than or equal to the price',
-        },
-        { status: 400 }
-      );
-    }
-
-    const cabin = await Cabin.findByIdAndUpdate(
-      id,
-      sanitizeUpdatePayload(body),
-      {
-        new: true,
-        runValidators: true,
-      }
-    );
+    const cabin = await Cabin.findByIdAndUpdate(id, updateData, {
+      new: true,
+      runValidators: true,
+    });
 
     if (!cabin) {
       return NextResponse.json(

--- a/app/api/cabins/[id]/route.ts
+++ b/app/api/cabins/[id]/route.ts
@@ -64,14 +64,20 @@ export async function PUT(
 
     const { _id: _validatedId, ...updateData } = validationResult.data;
 
-    // A discount-only update has no `price` in the payload for the schema's
-    // refine to check against — compare it against the stored price instead.
-    if (updateData.discount !== undefined && updateData.price === undefined) {
-      const existingCabin = await Cabin.findById(id).select('price');
+    // An update touching only `discount` or only `price` has no counterpart
+    // in the payload for the schema's refine to check against — fetch the
+    // stored value of whichever field is missing and compare against that.
+    if (
+      (updateData.discount !== undefined) !==
+      (updateData.price !== undefined)
+    ) {
+      const existingCabin = await Cabin.findById(id);
       if (!existingCabin) {
         return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);
       }
-      if (!isDiscountValid(updateData.discount, existingCabin.price)) {
+      const effectiveDiscount = updateData.discount ?? existingCabin.discount;
+      const effectivePrice = updateData.price ?? existingCabin.price;
+      if (!isDiscountValid(effectiveDiscount, effectivePrice)) {
         return createErrorResponse(
           'Validation failed',
           HTTP_STATUS.BAD_REQUEST,

--- a/app/api/cabins/[id]/route.ts
+++ b/app/api/cabins/[id]/route.ts
@@ -1,8 +1,15 @@
-import { createValidationErrorResponse, requireApiAuth } from '@/lib/api-utils';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  createValidationErrorResponse,
+  HTTP_STATUS,
+  requireApiAuth,
+} from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
 import connectDB from '@/lib/mongodb';
-import { updateCabinSchema } from '@/lib/validations';
+import { isDiscountValid, updateCabinSchema } from '@/lib/validations';
 import { isMongooseValidationError } from '@/types/errors';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { Cabin } from '../../../../models';
 
 export async function GET(
@@ -20,26 +27,18 @@ export async function GET(
     const cabin = await Cabin.findById(id);
 
     if (!cabin) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Cabin not found',
-        },
-        { status: 404 }
-      );
+      return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);
     }
 
-    return NextResponse.json({
-      success: true,
-      data: cabin,
-    });
+    return createSuccessResponse(cabin);
   } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Failed to fetch cabin',
-      },
-      { status: 500 }
+    logger.error(
+      'Error fetching cabin',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to fetch cabin',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }
@@ -65,43 +64,50 @@ export async function PUT(
 
     const { _id: _validatedId, ...updateData } = validationResult.data;
 
+    // A discount-only update has no `price` in the payload for the schema's
+    // refine to check against — compare it against the stored price instead.
+    if (updateData.discount !== undefined && updateData.price === undefined) {
+      const existingCabin = await Cabin.findById(id).select('price');
+      if (!existingCabin) {
+        return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);
+      }
+      if (!isDiscountValid(updateData.discount, existingCabin.price)) {
+        return createErrorResponse(
+          'Validation failed',
+          HTTP_STATUS.BAD_REQUEST,
+          {
+            discount: ['Discount cannot be greater than or equal to the price'],
+          }
+        );
+      }
+    }
+
     const cabin = await Cabin.findByIdAndUpdate(id, updateData, {
       new: true,
       runValidators: true,
     });
 
     if (!cabin) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Cabin not found',
-        },
-        { status: 404 }
-      );
+      return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);
     }
 
-    return NextResponse.json({
-      success: true,
-      data: cabin,
-    });
+    return createSuccessResponse(cabin);
   } catch (error: unknown) {
     if (isMongooseValidationError(error)) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Validation failed',
-          details: error.errors,
-        },
-        { status: 400 }
+      return createErrorResponse(
+        'Validation failed',
+        HTTP_STATUS.BAD_REQUEST,
+        error.errors
       );
     }
 
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Failed to update cabin',
-      },
-      { status: 500 }
+    logger.error(
+      'Error updating cabin',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to update cabin',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }
@@ -121,26 +127,18 @@ export async function DELETE(
     const cabin = await Cabin.findByIdAndDelete(id);
 
     if (!cabin) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Cabin not found',
-        },
-        { status: 404 }
-      );
+      return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);
     }
 
-    return NextResponse.json({
-      success: true,
-      message: 'Cabin deleted successfully',
-    });
+    return createSuccessResponse(null, 'Cabin deleted successfully');
   } catch (error) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Failed to delete cabin',
-      },
-      { status: 500 }
+    logger.error(
+      'Error deleting cabin',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to delete cabin',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }

--- a/app/api/cabins/route.ts
+++ b/app/api/cabins/route.ts
@@ -6,8 +6,13 @@ import {
   HTTP_STATUS,
   requireApiAuth,
 } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
 import connectDB from '@/lib/mongodb';
-import { createCabinSchema, updateCabinSchema } from '@/lib/validations';
+import {
+  createCabinSchema,
+  isDiscountValid,
+  updateCabinSchema,
+} from '@/lib/validations';
 import type { CabinQueryFilter, MongoSortOrder } from '@/types/api';
 import { isMongooseValidationError } from '@/types/errors';
 import { NextRequest } from 'next/server';
@@ -108,7 +113,10 @@ export async function GET(request: NextRequest) {
 
     return createSuccessResponse(cabins);
   } catch (error) {
-    console.error('Error fetching cabins:', error);
+    logger.error(
+      'Error fetching cabins',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to fetch cabins',
       HTTP_STATUS.INTERNAL_SERVER_ERROR
@@ -135,8 +143,6 @@ export async function POST(request: NextRequest) {
 
     return createSuccessResponse(cabin, undefined, HTTP_STATUS.CREATED);
   } catch (error: unknown) {
-    console.error('Error creating cabin:', error);
-
     // Handle validation errors
     if (isMongooseValidationError(error)) {
       return createErrorResponse(
@@ -146,6 +152,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    logger.error(
+      'Error creating cabin',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to create cabin',
       HTTP_STATUS.INTERNAL_SERVER_ERROR
@@ -170,6 +180,24 @@ export async function PUT(request: NextRequest) {
 
     const { _id, ...updateData } = validationResult.data;
 
+    // A discount-only update has no `price` in the payload for the schema's
+    // refine to check against — compare it against the stored price instead.
+    if (updateData.discount !== undefined && updateData.price === undefined) {
+      const existingCabin = await Cabin.findById(_id).select('price');
+      if (!existingCabin) {
+        return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);
+      }
+      if (!isDiscountValid(updateData.discount, existingCabin.price)) {
+        return createErrorResponse(
+          'Validation failed',
+          HTTP_STATUS.BAD_REQUEST,
+          {
+            discount: ['Discount cannot be greater than or equal to the price'],
+          }
+        );
+      }
+    }
+
     const cabin = await Cabin.findByIdAndUpdate(_id, updateData, {
       new: true,
       runValidators: true,
@@ -181,8 +209,6 @@ export async function PUT(request: NextRequest) {
 
     return createSuccessResponse(cabin);
   } catch (error: unknown) {
-    console.error('Error updating cabin:', error);
-
     if (isMongooseValidationError(error)) {
       return createErrorResponse(
         'Validation failed',
@@ -191,6 +217,10 @@ export async function PUT(request: NextRequest) {
       );
     }
 
+    logger.error(
+      'Error updating cabin',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to update cabin',
       HTTP_STATUS.INTERNAL_SERVER_ERROR
@@ -224,7 +254,10 @@ export async function DELETE(request: NextRequest) {
 
     return createSuccessResponse(null, 'Cabin deleted successfully');
   } catch (error) {
-    console.error('Error deleting cabin:', error);
+    logger.error(
+      'Error deleting cabin',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to delete cabin',
       HTTP_STATUS.INTERNAL_SERVER_ERROR

--- a/app/api/cabins/route.ts
+++ b/app/api/cabins/route.ts
@@ -1,12 +1,13 @@
 import {
   createErrorResponse,
   createSuccessResponse,
+  createValidationErrorResponse,
   escapeRegex,
   HTTP_STATUS,
   requireApiAuth,
-  sanitizeUpdatePayload,
 } from '@/lib/api-utils';
 import connectDB from '@/lib/mongodb';
+import { createCabinSchema, updateCabinSchema } from '@/lib/validations';
 import type { CabinQueryFilter, MongoSortOrder } from '@/types/api';
 import { isMongooseValidationError } from '@/types/errors';
 import { NextRequest } from 'next/server';
@@ -125,15 +126,12 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
 
-    // Validate discount vs price
-    if (body.discount && body.discount >= body.price) {
-      return createErrorResponse(
-        'Discount cannot be greater than or equal to the price',
-        HTTP_STATUS.BAD_REQUEST
-      );
+    const validationResult = createCabinSchema.safeParse(body);
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
     }
 
-    const cabin = await Cabin.create(body);
+    const cabin = await Cabin.create(validationResult.data);
 
     return createSuccessResponse(cabin, undefined, HTTP_STATUS.CREATED);
   } catch (error: unknown) {
@@ -164,23 +162,18 @@ export async function PUT(request: NextRequest) {
     await connectDB();
 
     const body = await request.json();
-    const { _id, ...updateData } = body;
 
-    if (!_id) {
-      return createErrorResponse(
-        'Cabin ID is required',
-        HTTP_STATUS.BAD_REQUEST
-      );
+    const validationResult = updateCabinSchema.safeParse(body);
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
     }
 
-    const cabin = await Cabin.findByIdAndUpdate(
-      _id,
-      sanitizeUpdatePayload(updateData),
-      {
-        new: true,
-        runValidators: true,
-      }
-    );
+    const { _id, ...updateData } = validationResult.data;
+
+    const cabin = await Cabin.findByIdAndUpdate(_id, updateData, {
+      new: true,
+      runValidators: true,
+    });
 
     if (!cabin) {
       return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);

--- a/app/api/cabins/route.ts
+++ b/app/api/cabins/route.ts
@@ -180,14 +180,20 @@ export async function PUT(request: NextRequest) {
 
     const { _id, ...updateData } = validationResult.data;
 
-    // A discount-only update has no `price` in the payload for the schema's
-    // refine to check against — compare it against the stored price instead.
-    if (updateData.discount !== undefined && updateData.price === undefined) {
-      const existingCabin = await Cabin.findById(_id).select('price');
+    // An update touching only `discount` or only `price` has no counterpart
+    // in the payload for the schema's refine to check against — fetch the
+    // stored value of whichever field is missing and compare against that.
+    if (
+      (updateData.discount !== undefined) !==
+      (updateData.price !== undefined)
+    ) {
+      const existingCabin = await Cabin.findById(_id);
       if (!existingCabin) {
         return createErrorResponse('Cabin not found', HTTP_STATUS.NOT_FOUND);
       }
-      if (!isDiscountValid(updateData.discount, existingCabin.price)) {
+      const effectiveDiscount = updateData.discount ?? existingCabin.discount;
+      const effectivePrice = updateData.price ?? existingCabin.price;
+      if (!isDiscountValid(effectiveDiscount, effectivePrice)) {
         return createErrorResponse(
           'Validation failed',
           HTTP_STATUS.BAD_REQUEST,

--- a/app/api/dining/[id]/route.ts
+++ b/app/api/dining/[id]/route.ts
@@ -1,4 +1,5 @@
-import { requireApiAuth, sanitizeUpdatePayload } from '@/lib/api-utils';
+import { createValidationErrorResponse, requireApiAuth } from '@/lib/api-utils';
+import { updateDiningSchema } from '@/lib/validations';
 import { connectDB, Dining } from '@/models';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -50,28 +51,17 @@ export async function PUT(
     const body = await request.json();
     const { id } = await params;
 
-    // Validate serving time format if provided
-    if (body.servingTime) {
-      const timeRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
-      if (
-        !timeRegex.test(body.servingTime.start) ||
-        !timeRegex.test(body.servingTime.end)
-      ) {
-        return NextResponse.json(
-          { success: false, error: 'Invalid time format. Use HH:MM format.' },
-          { status: 400 }
-        );
-      }
+    const validationResult = updateDiningSchema.safeParse({ ...body, _id: id });
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
     }
 
-    const dining = await Dining.findByIdAndUpdate(
-      id,
-      sanitizeUpdatePayload(body),
-      {
-        new: true,
-        runValidators: true,
-      }
-    );
+    const { _id: _validatedId, ...updateData } = validationResult.data;
+
+    const dining = await Dining.findByIdAndUpdate(id, updateData, {
+      new: true,
+      runValidators: true,
+    });
 
     if (!dining) {
       return NextResponse.json(

--- a/app/api/dining/[id]/route.ts
+++ b/app/api/dining/[id]/route.ts
@@ -1,7 +1,15 @@
-import { createValidationErrorResponse, requireApiAuth } from '@/lib/api-utils';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  createValidationErrorResponse,
+  HTTP_STATUS,
+  requireApiAuth,
+} from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
 import { updateDiningSchema } from '@/lib/validations';
 import { connectDB, Dining } from '@/models';
-import { NextRequest, NextResponse } from 'next/server';
+import { isMongooseValidationError } from '@/types/errors';
+import { NextRequest } from 'next/server';
 
 export async function GET(
   _req: NextRequest,
@@ -18,21 +26,21 @@ export async function GET(
     const dining = await Dining.findById(id);
 
     if (!dining) {
-      return NextResponse.json(
-        { success: false, error: 'Dining item not found' },
-        { status: 404 }
+      return createErrorResponse(
+        'Dining item not found',
+        HTTP_STATUS.NOT_FOUND
       );
     }
 
-    return NextResponse.json({
-      success: true,
-      data: dining,
-    });
+    return createSuccessResponse(dining);
   } catch (error) {
-    console.error('Error fetching dining item:', error);
-    return NextResponse.json(
-      { success: false, error: 'Failed to fetch dining item' },
-      { status: 500 }
+    logger.error(
+      'Error fetching dining item',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to fetch dining item',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }
@@ -64,22 +72,29 @@ export async function PUT(
     });
 
     if (!dining) {
-      return NextResponse.json(
-        { success: false, error: 'Dining item not found' },
-        { status: 404 }
+      return createErrorResponse(
+        'Dining item not found',
+        HTTP_STATUS.NOT_FOUND
       );
     }
 
-    return NextResponse.json({
-      success: true,
-      data: dining,
-      message: 'Dining item updated successfully',
-    });
-  } catch (error) {
-    console.error('Error updating dining item:', error);
-    return NextResponse.json(
-      { success: false, error: 'Failed to update dining item' },
-      { status: 500 }
+    return createSuccessResponse(dining, 'Dining item updated successfully');
+  } catch (error: unknown) {
+    if (isMongooseValidationError(error)) {
+      return createErrorResponse(
+        'Validation failed',
+        HTTP_STATUS.BAD_REQUEST,
+        error.errors
+      );
+    }
+
+    logger.error(
+      'Error updating dining item',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to update dining item',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }
@@ -99,21 +114,21 @@ export async function DELETE(
     const dining = await Dining.findByIdAndDelete(id);
 
     if (!dining) {
-      return NextResponse.json(
-        { success: false, error: 'Dining item not found' },
-        { status: 404 }
+      return createErrorResponse(
+        'Dining item not found',
+        HTTP_STATUS.NOT_FOUND
       );
     }
 
-    return NextResponse.json({
-      success: true,
-      message: 'Dining item deleted successfully',
-    });
+    return createSuccessResponse(null, 'Dining item deleted successfully');
   } catch (error) {
-    console.error('Error deleting dining item:', error);
-    return NextResponse.json(
-      { success: false, error: 'Failed to delete dining item' },
-      { status: 500 }
+    logger.error(
+      'Error deleting dining item',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to delete dining item',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }

--- a/app/api/dining/route.ts
+++ b/app/api/dining/route.ts
@@ -1,11 +1,12 @@
 import {
   createErrorResponse,
   createSuccessResponse,
+  createValidationErrorResponse,
   escapeRegex,
   HTTP_STATUS,
   requireApiAuth,
-  sanitizeUpdatePayload,
 } from '@/lib/api-utils';
+import { createDiningSchema, updateDiningSchema } from '@/lib/validations';
 import { connectDB, Dining } from '@/models';
 import type { DiningQueryFilter, MongoSortOrder } from '@/types/api';
 import { NextRequest } from 'next/server';
@@ -97,40 +98,12 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
 
-    // Validate required fields
-    const requiredFields = [
-      'name',
-      'description',
-      'type',
-      'mealType',
-      'price',
-      'servingTime',
-      'maxPeople',
-      'category',
-      'image',
-    ];
-    const missingFields = requiredFields.filter(field => !body[field]);
-
-    if (missingFields.length > 0) {
-      return createErrorResponse(
-        `Missing required fields: ${missingFields.join(', ')}`,
-        HTTP_STATUS.BAD_REQUEST
-      );
+    const validationResult = createDiningSchema.safeParse(body);
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
     }
 
-    // Validate serving time format
-    const timeRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
-    if (
-      !timeRegex.test(body.servingTime.start) ||
-      !timeRegex.test(body.servingTime.end)
-    ) {
-      return createErrorResponse(
-        'Invalid time format. Use HH:MM format.',
-        HTTP_STATUS.BAD_REQUEST
-      );
-    }
-
-    const dining = new Dining(body);
+    const dining = new Dining(validationResult.data);
     await dining.save();
 
     return createSuccessResponse(
@@ -156,37 +129,18 @@ export async function PUT(request: NextRequest) {
     await connectDB();
 
     const body = await request.json();
-    const { _id, ...updateData } = body;
 
-    if (!_id) {
-      return createErrorResponse(
-        'Dining item ID is required',
-        HTTP_STATUS.BAD_REQUEST
-      );
+    const validationResult = updateDiningSchema.safeParse(body);
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
     }
 
-    // Validate serving time format if provided
-    if (updateData.servingTime) {
-      const timeRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
-      if (
-        !timeRegex.test(updateData.servingTime.start) ||
-        !timeRegex.test(updateData.servingTime.end)
-      ) {
-        return createErrorResponse(
-          'Invalid time format. Use HH:MM format.',
-          HTTP_STATUS.BAD_REQUEST
-        );
-      }
-    }
+    const { _id, ...updateData } = validationResult.data;
 
-    const dining = await Dining.findByIdAndUpdate(
-      _id,
-      sanitizeUpdatePayload(updateData),
-      {
-        new: true,
-        runValidators: true,
-      }
-    );
+    const dining = await Dining.findByIdAndUpdate(_id, updateData, {
+      new: true,
+      runValidators: true,
+    });
 
     if (!dining) {
       return createErrorResponse(

--- a/app/api/dining/route.ts
+++ b/app/api/dining/route.ts
@@ -6,9 +6,11 @@ import {
   HTTP_STATUS,
   requireApiAuth,
 } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
 import { createDiningSchema, updateDiningSchema } from '@/lib/validations';
 import { connectDB, Dining } from '@/models';
 import type { DiningQueryFilter, MongoSortOrder } from '@/types/api';
+import { isMongooseValidationError } from '@/types/errors';
 import { NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
@@ -80,7 +82,10 @@ export async function GET(request: NextRequest) {
 
     return createSuccessResponse(dining);
   } catch (error) {
-    console.error('Error fetching dining:', error);
+    logger.error(
+      'Error fetching dining',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to fetch dining items',
       HTTP_STATUS.INTERNAL_SERVER_ERROR
@@ -111,8 +116,19 @@ export async function POST(request: NextRequest) {
       'Dining item created successfully',
       HTTP_STATUS.CREATED
     );
-  } catch (error) {
-    console.error('Error creating dining item:', error);
+  } catch (error: unknown) {
+    if (isMongooseValidationError(error)) {
+      return createErrorResponse(
+        'Validation failed',
+        HTTP_STATUS.BAD_REQUEST,
+        error.errors
+      );
+    }
+
+    logger.error(
+      'Error creating dining item',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to create dining item',
       HTTP_STATUS.INTERNAL_SERVER_ERROR
@@ -150,8 +166,19 @@ export async function PUT(request: NextRequest) {
     }
 
     return createSuccessResponse(dining, 'Dining item updated successfully');
-  } catch (error) {
-    console.error('Error updating dining item:', error);
+  } catch (error: unknown) {
+    if (isMongooseValidationError(error)) {
+      return createErrorResponse(
+        'Validation failed',
+        HTTP_STATUS.BAD_REQUEST,
+        error.errors
+      );
+    }
+
+    logger.error(
+      'Error updating dining item',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to update dining item',
       HTTP_STATUS.INTERNAL_SERVER_ERROR
@@ -188,7 +215,10 @@ export async function DELETE(request: NextRequest) {
 
     return createSuccessResponse(null, 'Dining item deleted successfully');
   } catch (error) {
-    console.error('Error deleting dining item:', error);
+    logger.error(
+      'Error deleting dining item',
+      error instanceof Error ? error : undefined
+    );
     return createErrorResponse(
       'Failed to delete dining item',
       HTTP_STATUS.INTERNAL_SERVER_ERROR

--- a/app/api/experiences/[id]/route.ts
+++ b/app/api/experiences/[id]/route.ts
@@ -1,5 +1,6 @@
-import { requireApiAuth, sanitizeUpdatePayload } from '@/lib/api-utils';
+import { createValidationErrorResponse, requireApiAuth } from '@/lib/api-utils';
 import connectToDatabase from '@/lib/mongodb';
+import { updateExperienceSchema } from '@/lib/validations';
 import { Experience } from '@/models/Experience';
 import { NextResponse } from 'next/server';
 
@@ -40,9 +41,15 @@ export async function PUT(request: Request, { params }: ParamProps) {
   try {
     await connectToDatabase();
     const data = await request.json();
+
+    const validationResult = updateExperienceSchema.safeParse(data);
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
+    }
+
     const experience = await Experience.findByIdAndUpdate(
       id,
-      sanitizeUpdatePayload(data),
+      validationResult.data,
       {
         new: true,
         runValidators: true,

--- a/app/api/experiences/[id]/route.ts
+++ b/app/api/experiences/[id]/route.ts
@@ -1,8 +1,15 @@
-import { createValidationErrorResponse, requireApiAuth } from '@/lib/api-utils';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  createValidationErrorResponse,
+  HTTP_STATUS,
+  requireApiAuth,
+} from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
 import connectToDatabase from '@/lib/mongodb';
 import { updateExperienceSchema } from '@/lib/validations';
 import { Experience } from '@/models/Experience';
-import { NextResponse } from 'next/server';
+import { isMongooseValidationError } from '@/types/errors';
 
 type ParamProps = {
   params: Promise<{ id: string }>;
@@ -18,16 +25,18 @@ export async function GET(_request: Request, { params }: ParamProps) {
     await connectToDatabase();
     const experience = await Experience.findById(id);
     if (!experience) {
-      return NextResponse.json(
-        { error: 'Experience not found' },
-        { status: 404 }
-      );
+      return createErrorResponse('Experience not found', HTTP_STATUS.NOT_FOUND);
     }
-    return NextResponse.json(experience);
+
+    return createSuccessResponse(experience);
   } catch (error) {
-    return NextResponse.json(
-      { error: 'Failed to fetch experience' },
-      { status: 500 }
+    logger.error(
+      'Error fetching experience',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to fetch experience',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }
@@ -42,30 +51,41 @@ export async function PUT(request: Request, { params }: ParamProps) {
     await connectToDatabase();
     const data = await request.json();
 
-    const validationResult = updateExperienceSchema.safeParse(data);
+    const validationResult = updateExperienceSchema.safeParse({
+      ...data,
+      _id: id,
+    });
     if (!validationResult.success) {
       return createValidationErrorResponse(validationResult.error);
     }
 
-    const experience = await Experience.findByIdAndUpdate(
-      id,
-      validationResult.data,
-      {
-        new: true,
-        runValidators: true,
-      }
-    );
+    const { _id: _validatedId, ...updateData } = validationResult.data;
+
+    const experience = await Experience.findByIdAndUpdate(id, updateData, {
+      new: true,
+      runValidators: true,
+    });
     if (!experience) {
-      return NextResponse.json(
-        { error: 'Experience not found' },
-        { status: 404 }
+      return createErrorResponse('Experience not found', HTTP_STATUS.NOT_FOUND);
+    }
+
+    return createSuccessResponse(experience);
+  } catch (error: unknown) {
+    if (isMongooseValidationError(error)) {
+      return createErrorResponse(
+        'Validation failed',
+        HTTP_STATUS.BAD_REQUEST,
+        error.errors
       );
     }
-    return NextResponse.json(experience);
-  } catch (error) {
-    return NextResponse.json(
-      { error: 'Failed to update experience' },
-      { status: 500 }
+
+    logger.error(
+      'Error updating experience',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to update experience',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }
@@ -80,16 +100,18 @@ export async function DELETE(_request: Request, { params }: ParamProps) {
     await connectToDatabase();
     const experience = await Experience.findByIdAndDelete(id);
     if (!experience) {
-      return NextResponse.json(
-        { error: 'Experience not found' },
-        { status: 404 }
-      );
+      return createErrorResponse('Experience not found', HTTP_STATUS.NOT_FOUND);
     }
-    return NextResponse.json({ message: 'Experience deleted' });
+
+    return createSuccessResponse(null, 'Experience deleted successfully');
   } catch (error) {
-    return NextResponse.json(
-      { error: 'Failed to delete experience' },
-      { status: 500 }
+    logger.error(
+      'Error deleting experience',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to delete experience',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }

--- a/app/api/experiences/route.ts
+++ b/app/api/experiences/route.ts
@@ -1,12 +1,17 @@
 import {
+  createErrorResponse,
+  createSuccessResponse,
   createValidationErrorResponse,
   escapeRegex,
+  HTTP_STATUS,
   requireApiAuth,
 } from '@/lib/api-utils';
+import { logger } from '@/lib/logger';
 import connectToDatabase from '@/lib/mongodb';
 import { createExperienceSchema } from '@/lib/validations';
 import { Experience } from '@/models/Experience';
-import { NextRequest, NextResponse } from 'next/server';
+import { isMongooseValidationError } from '@/types/errors';
+import { NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
   // Require authentication
@@ -59,14 +64,15 @@ export async function GET(request: NextRequest) {
     }
 
     const experiences = await Experience.find(query).sort(sort);
-    return NextResponse.json({
-      success: true,
-      data: experiences,
-    });
+    return createSuccessResponse(experiences);
   } catch (error) {
-    return NextResponse.json(
-      { success: false, error: 'Failed to fetch experiences' },
-      { status: 500 }
+    logger.error(
+      'Error fetching experiences',
+      error instanceof Error ? error : undefined
+    );
+    return createErrorResponse(
+      'Failed to fetch experiences',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }
@@ -87,14 +93,24 @@ export async function POST(request: Request) {
 
     const experience = new Experience(validationResult.data);
     await experience.save();
-    return NextResponse.json(
-      { success: true, data: experience },
-      { status: 201 }
+
+    return createSuccessResponse(experience, undefined, HTTP_STATUS.CREATED);
+  } catch (error: unknown) {
+    if (isMongooseValidationError(error)) {
+      return createErrorResponse(
+        'Validation failed',
+        HTTP_STATUS.BAD_REQUEST,
+        error.errors
+      );
+    }
+
+    logger.error(
+      'Error creating experience',
+      error instanceof Error ? error : undefined
     );
-  } catch (error) {
-    return NextResponse.json(
-      { success: false, error: 'Failed to create experience' },
-      { status: 500 }
+    return createErrorResponse(
+      'Failed to create experience',
+      HTTP_STATUS.INTERNAL_SERVER_ERROR
     );
   }
 }

--- a/app/api/experiences/route.ts
+++ b/app/api/experiences/route.ts
@@ -1,5 +1,10 @@
-import { escapeRegex, requireApiAuth } from '@/lib/api-utils';
+import {
+  createValidationErrorResponse,
+  escapeRegex,
+  requireApiAuth,
+} from '@/lib/api-utils';
 import connectToDatabase from '@/lib/mongodb';
+import { createExperienceSchema } from '@/lib/validations';
 import { Experience } from '@/models/Experience';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -74,7 +79,13 @@ export async function POST(request: Request) {
   try {
     await connectToDatabase();
     const data = await request.json();
-    const experience = new Experience(data);
+
+    const validationResult = createExperienceSchema.safeParse(data);
+    if (!validationResult.success) {
+      return createValidationErrorResponse(validationResult.error);
+    }
+
+    const experience = new Experience(validationResult.data);
     await experience.save();
     return NextResponse.json(
       { success: true, data: experience },

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -84,6 +84,53 @@ export const VALID_TRANSITIONS: Record<
 } as const;
 
 /**
+ * Cabin/Dining/Experience Enum Values — single source of truth for Zod and Mongoose
+ */
+export const CABIN_STATUSES = ['active', 'maintenance', 'inactive'] as const;
+
+export const DINING_TYPES = ['menu', 'experience'] as const;
+
+export const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'all-day'] as const;
+
+export const DINING_CATEGORIES = [
+  'regular',
+  'craft-beer',
+  'wine',
+  'spirits',
+  'non-alcoholic',
+] as const;
+
+export const BEVERAGE_CATEGORIES = [
+  'craft-beer',
+  'wine',
+  'spirits',
+  'non-alcoholic',
+] as const;
+
+export const DIETARY_OPTIONS = [
+  'vegetarian',
+  'vegan',
+  'gluten-free',
+  'dairy-free',
+  'keto',
+  'paleo',
+] as const;
+
+export const EXPERIENCE_DIFFICULTIES = [
+  'Easy',
+  'Moderate',
+  'Challenging',
+] as const;
+
+export type CabinStatus = (typeof CABIN_STATUSES)[number];
+export type DiningType = (typeof DINING_TYPES)[number];
+export type MealType = (typeof MEAL_TYPES)[number];
+export type DiningCategory = (typeof DINING_CATEGORIES)[number];
+export type BeverageCategory = (typeof BEVERAGE_CATEGORIES)[number];
+export type DietaryOption = (typeof DIETARY_OPTIONS)[number];
+export type ExperienceDifficulty = (typeof EXPERIENCE_DIFFICULTIES)[number];
+
+/**
  * Loyalty Tier Thresholds
  */
 export const LOYALTY_TIERS = {

--- a/lib/validations/cabin.ts
+++ b/lib/validations/cabin.ts
@@ -1,9 +1,10 @@
+import { CABIN_STATUSES } from '@/lib/config';
 import { z } from 'zod';
 
 /**
  * Status enum — matches the Cabin Mongoose model
  */
-const cabinStatusSchema = z.enum(['active', 'maintenance', 'inactive']);
+const cabinStatusSchema = z.enum(CABIN_STATUSES);
 
 /**
  * Description length bounds — kept as constants so create/update can't
@@ -86,6 +87,15 @@ export const updateCabinSchema = z
       path: ['discount'],
     }
   );
+
+/**
+ * A discount-only update (no `price` in the payload) can't be checked by the
+ * refine above, since it has no persisted price to compare against. Routes
+ * must call this against the cabin's stored price before persisting.
+ */
+export function isDiscountValid(discount: number, price: number): boolean {
+  return discount < price;
+}
 
 export type CreateCabinInput = z.infer<typeof createCabinSchema>;
 export type UpdateCabinInput = z.infer<typeof updateCabinSchema>;

--- a/lib/validations/cabin.ts
+++ b/lib/validations/cabin.ts
@@ -1,21 +1,44 @@
 import { z } from 'zod';
 
 /**
+ * Status enum — matches the Cabin Mongoose model
+ */
+const cabinStatusSchema = z.enum(['active', 'maintenance', 'inactive']);
+
+/**
+ * Description length bounds — kept as constants so create/update can't
+ * drift apart the way they previously did (create allowed 1000 chars,
+ * update allowed 2000, while the Cabin model itself caps at 1000).
+ */
+const CABIN_DESCRIPTION_MIN = 10;
+const CABIN_DESCRIPTION_MAX = 1000;
+
+/**
  * Create cabin request schema
  */
 export const createCabinSchema = z
   .object({
     name: z.string().min(1, 'Name is required').max(100),
-    description: z
-      .string()
-      .min(10, 'Description must be at least 10 characters')
-      .max(1000),
+    image: z.string().url('Invalid image URL'),
+    images: z.array(z.string().url('Invalid image URL')).optional().default([]),
+    status: cabinStatusSchema.optional().default('active'),
     capacity: z.number().int().min(1, 'Capacity must be at least 1').max(20),
     price: z.number().positive('Price must be positive'),
     discount: z.number().min(0).optional().default(0),
-    image: z.string().url('Invalid image URL').optional(),
+    description: z
+      .string()
+      .min(CABIN_DESCRIPTION_MIN, 'Description must be at least 10 characters')
+      .max(CABIN_DESCRIPTION_MAX),
     amenities: z.array(z.string().trim().min(1)).optional().default([]),
-    isAvailable: z.boolean().optional().default(true),
+    bedrooms: z.number().min(1, 'Bedrooms must be at least 1').optional(),
+    bathrooms: z.number().min(1, 'Bathrooms must be at least 1').optional(),
+    size: z.number().min(1, 'Size must be at least 1 sq ft').optional(),
+    minNights: z
+      .number()
+      .int()
+      .min(1, 'Minimum nights must be at least 1')
+      .optional(),
+    extraGuestFee: z.number().min(0).optional().default(0),
   })
   .refine(data => !data.discount || data.discount < data.price, {
     message: 'Discount cannot be greater than or equal to the price',
@@ -23,19 +46,33 @@ export const createCabinSchema = z
   });
 
 /**
- * Update cabin request schema
+ * Update cabin request schema (all fields optional except _id).
+ *
+ * Deliberately not derived via `.partial()` on the create schema — fields
+ * there carry `.default()`, which Zod applies even when the key is absent
+ * from a partial update, silently resetting them to create-time defaults.
  */
 export const updateCabinSchema = z
   .object({
     _id: z.string().min(1, 'Cabin ID is required'),
     name: z.string().min(1).max(100).optional(),
-    description: z.string().min(10).max(2000).optional(),
+    image: z.string().url('Invalid image URL').optional(),
+    images: z.array(z.string().url('Invalid image URL')).optional(),
+    status: cabinStatusSchema.optional(),
     capacity: z.number().int().min(1).max(20).optional(),
     price: z.number().positive().optional(),
     discount: z.number().min(0).optional(),
-    image: z.string().url().optional(),
-    amenities: z.array(z.string().trim().min(1)).optional().default([]),
-    isAvailable: z.boolean().optional(),
+    description: z
+      .string()
+      .min(CABIN_DESCRIPTION_MIN)
+      .max(CABIN_DESCRIPTION_MAX)
+      .optional(),
+    amenities: z.array(z.string().trim().min(1)).optional(),
+    bedrooms: z.number().min(1).optional(),
+    bathrooms: z.number().min(1).optional(),
+    size: z.number().min(1).optional(),
+    minNights: z.number().int().min(1).optional(),
+    extraGuestFee: z.number().min(0).optional(),
   })
   .refine(
     data => {

--- a/lib/validations/dining.ts
+++ b/lib/validations/dining.ts
@@ -14,28 +14,60 @@ const servingTimeSchema = z.object({
 });
 
 /**
- * Dining type enum
+ * Dining type enum — matches the Dining Mongoose model
  */
-export const diningTypeSchema = z.enum([
+export const diningTypeSchema = z.enum(['menu', 'experience']);
+
+/**
+ * Meal type enum — matches the Dining Mongoose model
+ */
+export const mealTypeSchema = z.enum([
   'breakfast',
   'lunch',
   'dinner',
-  'snack',
-  'beverage',
-  'dessert',
+  'all-day',
 ]);
 
 /**
- * Meal type enum
+ * Category enum — matches the Dining Mongoose model
  */
-export const mealTypeSchema = z.enum([
+export const diningCategorySchema = z.enum([
+  'regular',
+  'craft-beer',
+  'wine',
+  'spirits',
+  'non-alcoholic',
+]);
+
+/**
+ * Dietary option enum — matches the Dining Mongoose model
+ */
+export const dietaryOptionSchema = z.enum([
   'vegetarian',
   'vegan',
   'gluten-free',
   'dairy-free',
-  'nut-free',
-  'regular',
+  'keto',
+  'paleo',
 ]);
+
+/**
+ * Beverage sub-schema — matches the Dining Mongoose model's beverages array
+ */
+const beverageSchema = z.object({
+  name: z.string().min(1, 'Beverage name is required'),
+  description: z.string().optional(),
+  price: z.number().min(0).optional(),
+  alcoholContent: z.number().min(0).optional(),
+  category: z.enum(['craft-beer', 'wine', 'spirits', 'non-alcoholic']),
+});
+
+/**
+ * Description length bounds — kept as constants so create/update can't
+ * drift apart.
+ */
+const DINING_DESCRIPTION_MIN = 10;
+const DINING_DESCRIPTION_MAX = 1000;
 
 /**
  * Create dining item request schema
@@ -44,41 +76,73 @@ export const createDiningSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
   description: z
     .string()
-    .min(10, 'Description must be at least 10 characters')
-    .max(1000),
+    .min(DINING_DESCRIPTION_MIN, 'Description must be at least 10 characters')
+    .max(DINING_DESCRIPTION_MAX),
   type: diningTypeSchema,
   mealType: mealTypeSchema,
-  category: z.string().min(1, 'Category is required').max(50),
+  category: diningCategorySchema,
+  subCategory: z.string().max(50).optional(),
   price: z.number().positive('Price must be positive'),
   servingTime: servingTimeSchema,
   maxPeople: z.number().int().min(1).max(100),
+  minPeople: z.number().int().min(1).optional().default(1),
   image: z.string().url('Invalid image URL'),
+  gallery: z.array(z.string().url('Invalid image URL')).optional(),
   ingredients: z.array(z.string()).optional(),
   allergens: z.array(z.string()).optional(),
-  calories: z.number().int().min(0).optional(),
-  isAvailable: z.boolean().optional().default(true),
+  dietary: z.array(dietaryOptionSchema).optional(),
+  beverages: z.array(beverageSchema).optional(),
+  includes: z.array(z.string()).optional(),
+  duration: z.string().optional(),
+  location: z.string().optional(),
+  specialRequirements: z.array(z.string()).optional(),
   isPopular: z.boolean().optional().default(false),
+  isAvailable: z.boolean().optional().default(true),
+  seasonality: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  rating: z.number().min(0).max(5).optional(),
+  reviewCount: z.number().int().min(0).optional().default(0),
 });
 
 /**
- * Update dining item request schema
+ * Update dining item request schema (all fields optional except _id).
+ *
+ * Deliberately not derived via `.partial()` on the create schema — fields
+ * there carry `.default()`, which Zod applies even when the key is absent
+ * from a partial update, silently resetting them to create-time defaults.
  */
 export const updateDiningSchema = z.object({
   _id: z.string().min(1, 'Dining item ID is required'),
   name: z.string().min(1).max(100).optional(),
-  description: z.string().min(10).max(1000).optional(),
+  description: z
+    .string()
+    .min(DINING_DESCRIPTION_MIN)
+    .max(DINING_DESCRIPTION_MAX)
+    .optional(),
   type: diningTypeSchema.optional(),
   mealType: mealTypeSchema.optional(),
-  category: z.string().min(1).max(50).optional(),
+  category: diningCategorySchema.optional(),
+  subCategory: z.string().max(50).optional(),
   price: z.number().positive().optional(),
   servingTime: servingTimeSchema.optional(),
   maxPeople: z.number().int().min(1).max(100).optional(),
+  minPeople: z.number().int().min(1).optional(),
   image: z.string().url().optional(),
+  gallery: z.array(z.string().url('Invalid image URL')).optional(),
   ingredients: z.array(z.string()).optional(),
   allergens: z.array(z.string()).optional(),
-  calories: z.number().int().min(0).optional(),
-  isAvailable: z.boolean().optional(),
+  dietary: z.array(dietaryOptionSchema).optional(),
+  beverages: z.array(beverageSchema).optional(),
+  includes: z.array(z.string()).optional(),
+  duration: z.string().optional(),
+  location: z.string().optional(),
+  specialRequirements: z.array(z.string()).optional(),
   isPopular: z.boolean().optional(),
+  isAvailable: z.boolean().optional(),
+  seasonality: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  rating: z.number().min(0).max(5).optional(),
+  reviewCount: z.number().int().min(0).optional(),
 });
 
 export type CreateDiningInput = z.infer<typeof createDiningSchema>;

--- a/lib/validations/dining.ts
+++ b/lib/validations/dining.ts
@@ -1,3 +1,10 @@
+import {
+  BEVERAGE_CATEGORIES,
+  DIETARY_OPTIONS,
+  DINING_CATEGORIES,
+  DINING_TYPES,
+  MEAL_TYPES,
+} from '@/lib/config';
 import { z } from 'zod';
 
 /**
@@ -16,40 +23,22 @@ const servingTimeSchema = z.object({
 /**
  * Dining type enum — matches the Dining Mongoose model
  */
-export const diningTypeSchema = z.enum(['menu', 'experience']);
+export const diningTypeSchema = z.enum(DINING_TYPES);
 
 /**
  * Meal type enum — matches the Dining Mongoose model
  */
-export const mealTypeSchema = z.enum([
-  'breakfast',
-  'lunch',
-  'dinner',
-  'all-day',
-]);
+export const mealTypeSchema = z.enum(MEAL_TYPES);
 
 /**
  * Category enum — matches the Dining Mongoose model
  */
-export const diningCategorySchema = z.enum([
-  'regular',
-  'craft-beer',
-  'wine',
-  'spirits',
-  'non-alcoholic',
-]);
+export const diningCategorySchema = z.enum(DINING_CATEGORIES);
 
 /**
  * Dietary option enum — matches the Dining Mongoose model
  */
-export const dietaryOptionSchema = z.enum([
-  'vegetarian',
-  'vegan',
-  'gluten-free',
-  'dairy-free',
-  'keto',
-  'paleo',
-]);
+export const dietaryOptionSchema = z.enum(DIETARY_OPTIONS);
 
 /**
  * Beverage sub-schema — matches the Dining Mongoose model's beverages array
@@ -59,7 +48,7 @@ const beverageSchema = z.object({
   description: z.string().optional(),
   price: z.number().min(0).optional(),
   alcoholContent: z.number().min(0).optional(),
-  category: z.enum(['craft-beer', 'wine', 'spirits', 'non-alcoholic']),
+  category: z.enum(BEVERAGE_CATEGORIES),
 });
 
 /**

--- a/lib/validations/experience.ts
+++ b/lib/validations/experience.ts
@@ -40,9 +40,40 @@ export const createExperienceSchema = z
   .strict();
 
 /**
- * Update experience request schema
+ * Update experience request schema.
+ *
+ * Deliberately not derived via `.partial()` on the create schema — fields
+ * there carry `.default()`, which Zod applies even when the key is absent
+ * from a partial update, silently resetting them to create-time defaults.
  */
-export const updateExperienceSchema = createExperienceSchema.partial().strict();
+export const updateExperienceSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    description: z.string().min(1).max(2000).optional(),
+    duration: z.string().min(1).max(50).optional(),
+    price: z.number().min(0).optional(),
+    difficulty: difficultySchema.optional(),
+    category: z.string().min(1).max(50).optional(),
+    image: z.string().min(1).max(2048).optional(),
+    includes: z.array(z.string()).min(1).optional(),
+    available: z.array(z.string()).min(1).optional(),
+    ctaText: z.string().min(1).max(100).optional(),
+    longDescription: z.string().max(5000).optional(),
+    gallery: z.array(z.string()).optional(),
+    isPopular: z.boolean().optional(),
+    maxParticipants: z.number().int().min(1).max(500).optional(),
+    minAge: z.number().int().min(0).max(120).optional(),
+    requirements: z.array(z.string()).optional(),
+    location: z.string().max(200).optional(),
+    highlights: z.array(z.string()).optional(),
+    whatToBring: z.array(z.string()).optional(),
+    cancellationPolicy: z.string().max(500).optional(),
+    seasonality: z.string().max(200).optional(),
+    tags: z.array(z.string()).optional(),
+    rating: z.number().min(0).max(5).optional(),
+    reviewCount: z.number().int().min(0).optional(),
+  })
+  .strict();
 
 export type CreateExperienceInput = z.infer<typeof createExperienceSchema>;
 export type UpdateExperienceInput = z.infer<typeof updateExperienceSchema>;

--- a/lib/validations/experience.ts
+++ b/lib/validations/experience.ts
@@ -1,79 +1,84 @@
+import { EXPERIENCE_DIFFICULTIES } from '@/lib/config';
 import { z } from 'zod';
 
 /**
  * Difficulty enum
  */
-export const difficultySchema = z.enum(['Easy', 'Moderate', 'Challenging']);
+export const difficultySchema = z.enum(EXPERIENCE_DIFFICULTIES);
 
 /**
- * Create experience request schema
+ * Create experience request schema.
+ *
+ * Not `.strict()` — matches the cabin/dining create schemas, which silently
+ * strip unrecognized keys rather than rejecting the whole payload.
  */
-export const createExperienceSchema = z
-  .object({
-    name: z.string().min(1, 'Name is required').max(100),
-    description: z.string().min(1, 'Description is required').max(2000),
-    duration: z.string().min(1, 'Duration is required').max(50),
-    price: z.number().min(0, 'Price cannot be negative'),
-    difficulty: difficultySchema,
-    category: z.string().min(1, 'Category is required').max(50),
-    image: z.string().min(1, 'Image is required').max(2048),
-    includes: z.array(z.string()).min(1, 'At least one inclusion is required'),
-    available: z
-      .array(z.string())
-      .min(1, 'At least one availability option is required'),
-    ctaText: z.string().min(1, 'Call to action text is required').max(100),
-    longDescription: z.string().max(5000).optional(),
-    gallery: z.array(z.string()).optional(),
-    isPopular: z.boolean().optional().default(false),
-    maxParticipants: z.number().int().min(1).max(500).optional(),
-    minAge: z.number().int().min(0).max(120).optional(),
-    requirements: z.array(z.string()).optional(),
-    location: z.string().max(200).optional(),
-    highlights: z.array(z.string()).optional(),
-    whatToBring: z.array(z.string()).optional(),
-    cancellationPolicy: z.string().max(500).optional(),
-    seasonality: z.string().max(200).optional(),
-    tags: z.array(z.string()).optional(),
-    rating: z.number().min(0).max(5).optional(),
-    reviewCount: z.number().int().min(0).optional().default(0),
-  })
-  .strict();
+export const createExperienceSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  description: z.string().min(1, 'Description is required').max(2000),
+  duration: z.string().min(1, 'Duration is required').max(50),
+  price: z.number().min(0, 'Price cannot be negative'),
+  difficulty: difficultySchema,
+  category: z.string().min(1, 'Category is required').max(50),
+  image: z.string().min(1, 'Image is required').max(2048),
+  includes: z.array(z.string()).min(1, 'At least one inclusion is required'),
+  available: z
+    .array(z.string())
+    .min(1, 'At least one availability option is required'),
+  ctaText: z.string().min(1, 'Call to action text is required').max(100),
+  longDescription: z.string().max(5000).optional(),
+  gallery: z.array(z.string()).optional(),
+  isPopular: z.boolean().optional().default(false),
+  maxParticipants: z.number().int().min(1).max(500).optional(),
+  minAge: z.number().int().min(0).max(120).optional(),
+  requirements: z.array(z.string()).optional(),
+  location: z.string().max(200).optional(),
+  highlights: z.array(z.string()).optional(),
+  whatToBring: z.array(z.string()).optional(),
+  cancellationPolicy: z.string().max(500).optional(),
+  seasonality: z.string().max(200).optional(),
+  tags: z.array(z.string()).optional(),
+  rating: z.number().min(0).max(5).optional(),
+  reviewCount: z.number().int().min(0).optional().default(0),
+});
 
 /**
- * Update experience request schema.
+ * Update experience request schema (all fields optional except `_id`).
  *
  * Deliberately not derived via `.partial()` on the create schema — fields
  * there carry `.default()`, which Zod applies even when the key is absent
  * from a partial update, silently resetting them to create-time defaults.
+ *
+ * Not `.strict()` — matches cabin/dining. Clients round-trip a full
+ * `Experience` object (including `_id`, `createdAt`, `updatedAt`) back on
+ * save; unknown keys are silently stripped rather than rejecting the update.
  */
-export const updateExperienceSchema = z
-  .object({
-    name: z.string().min(1).max(100).optional(),
-    description: z.string().min(1).max(2000).optional(),
-    duration: z.string().min(1).max(50).optional(),
-    price: z.number().min(0).optional(),
-    difficulty: difficultySchema.optional(),
-    category: z.string().min(1).max(50).optional(),
-    image: z.string().min(1).max(2048).optional(),
-    includes: z.array(z.string()).min(1).optional(),
-    available: z.array(z.string()).min(1).optional(),
-    ctaText: z.string().min(1).max(100).optional(),
-    longDescription: z.string().max(5000).optional(),
-    gallery: z.array(z.string()).optional(),
-    isPopular: z.boolean().optional(),
-    maxParticipants: z.number().int().min(1).max(500).optional(),
-    minAge: z.number().int().min(0).max(120).optional(),
-    requirements: z.array(z.string()).optional(),
-    location: z.string().max(200).optional(),
-    highlights: z.array(z.string()).optional(),
-    whatToBring: z.array(z.string()).optional(),
-    cancellationPolicy: z.string().max(500).optional(),
-    seasonality: z.string().max(200).optional(),
-    tags: z.array(z.string()).optional(),
-    rating: z.number().min(0).max(5).optional(),
-    reviewCount: z.number().int().min(0).optional(),
-  })
-  .strict();
+export const updateExperienceSchema = z.object({
+  _id: z.string().min(1, 'Experience ID is required'),
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().min(1).max(2000).optional(),
+  duration: z.string().min(1).max(50).optional(),
+  price: z.number().min(0).optional(),
+  difficulty: difficultySchema.optional(),
+  category: z.string().min(1).max(50).optional(),
+  image: z.string().min(1).max(2048).optional(),
+  includes: z.array(z.string()).min(1).optional(),
+  available: z.array(z.string()).min(1).optional(),
+  ctaText: z.string().min(1).max(100).optional(),
+  longDescription: z.string().max(5000).optional(),
+  gallery: z.array(z.string()).optional(),
+  isPopular: z.boolean().optional(),
+  maxParticipants: z.number().int().min(1).max(500).optional(),
+  minAge: z.number().int().min(0).max(120).optional(),
+  requirements: z.array(z.string()).optional(),
+  location: z.string().max(200).optional(),
+  highlights: z.array(z.string()).optional(),
+  whatToBring: z.array(z.string()).optional(),
+  cancellationPolicy: z.string().max(500).optional(),
+  seasonality: z.string().max(200).optional(),
+  tags: z.array(z.string()).optional(),
+  rating: z.number().min(0).max(5).optional(),
+  reviewCount: z.number().int().min(0).optional(),
+});
 
 export type CreateExperienceInput = z.infer<typeof createExperienceSchema>;
 export type UpdateExperienceInput = z.infer<typeof updateExperienceSchema>;

--- a/models/Cabin.ts
+++ b/models/Cabin.ts
@@ -1,3 +1,4 @@
+import { CABIN_STATUSES } from '@/lib/config';
 import mongoose, { Document, Schema } from 'mongoose';
 
 export interface ICabin extends Document {
@@ -53,8 +54,20 @@ const CabinSchema: Schema = new Schema(
       default: 0,
       min: [0, 'Discount must be positive'],
       validate: {
-        validator: function (this: ICabin, value: number) {
-          return value < this.price;
+        // On `.create()`/`.save()`, `this` is the document, so `this.price`
+        // is the persisted price. On `findByIdAndUpdate`, `this` is the
+        // Query instead — the persisted price isn't visible here unless the
+        // update payload also sets `price`. A discount-only update (no
+        // `price` in the payload) can't be checked here; the API routes
+        // validate that case against the stored price before persisting.
+        validator: function (this: unknown, value: number) {
+          const query = this as { getUpdate?: () => Record<string, unknown> };
+          const price =
+            (this as Partial<ICabin>).price ??
+            (query.getUpdate?.()?.$set as Partial<ICabin> | undefined)?.price ??
+            (query.getUpdate?.() as Partial<ICabin> | undefined)?.price;
+          if (price === undefined) return true;
+          return value < price;
         },
         message: 'Discount must be less than the cabin price',
       },
@@ -84,7 +97,7 @@ const CabinSchema: Schema = new Schema(
     ],
     status: {
       type: String,
-      enum: ['active', 'maintenance', 'inactive'],
+      enum: CABIN_STATUSES,
       default: 'active',
     },
     bedrooms: {

--- a/models/Dining.ts
+++ b/models/Dining.ts
@@ -1,3 +1,10 @@
+import {
+  BEVERAGE_CATEGORIES,
+  DIETARY_OPTIONS,
+  DINING_CATEGORIES,
+  DINING_TYPES,
+  MEAL_TYPES,
+} from '@/lib/config';
 import { Schema, model, models } from 'mongoose';
 
 export interface IDining {
@@ -55,12 +62,12 @@ const diningSchema = new Schema(
     type: {
       type: String,
       required: true,
-      enum: ['menu', 'experience'],
+      enum: DINING_TYPES,
     },
     mealType: {
       type: String,
       required: true,
-      enum: ['breakfast', 'lunch', 'dinner', 'all-day'],
+      enum: MEAL_TYPES,
     },
     price: { type: Number, required: true },
     servingTime: {
@@ -72,7 +79,7 @@ const diningSchema = new Schema(
     category: {
       type: String,
       required: true,
-      enum: ['regular', 'craft-beer', 'wine', 'spirits', 'non-alcoholic'],
+      enum: DINING_CATEGORIES,
     },
     subCategory: { type: String },
     image: { type: String, required: true },
@@ -81,14 +88,7 @@ const diningSchema = new Schema(
     allergens: { type: [String], default: [] },
     dietary: {
       type: [String],
-      enum: [
-        'vegetarian',
-        'vegan',
-        'gluten-free',
-        'dairy-free',
-        'keto',
-        'paleo',
-      ],
+      enum: DIETARY_OPTIONS,
       default: [],
     },
     beverages: [
@@ -100,7 +100,7 @@ const diningSchema = new Schema(
         category: {
           type: String,
           required: true,
-          enum: ['craft-beer', 'wine', 'spirits', 'non-alcoholic'],
+          enum: BEVERAGE_CATEGORIES,
         },
       },
     ],

--- a/models/Experience.ts
+++ b/models/Experience.ts
@@ -1,3 +1,4 @@
+import { EXPERIENCE_DIFFICULTIES } from '@/lib/config';
 import { Schema, model, models } from 'mongoose';
 
 export interface IExperience {
@@ -38,7 +39,7 @@ const experienceSchema = new Schema(
     difficulty: {
       type: String,
       required: true,
-      enum: ['Easy', 'Moderate', 'Challenging'],
+      enum: EXPERIENCE_DIFFICULTIES,
     },
     category: { type: String, required: true },
     description: { type: String, required: true },


### PR DESCRIPTION
Closes #108.

## Summary
- Reconciles `createCabinSchema`/`updateCabinSchema` (`lib/validations/cabin.ts`) with the `Cabin` model: adds `status`, `images`, `bedrooms`, `bathrooms`, `size`, `minNights`, `extraGuestFee`; requires `image`; drops the nonexistent `isAvailable` field.
- Reconciles `createDiningSchema`/`updateDiningSchema` (`lib/validations/dining.ts`) with the `Dining` model: fixes the `type`/`mealType` enums, which were swapped and didn't match the model at all; fixes the `category` enum; adds `minPeople`, `subCategory`, `gallery`, `dietary`, `beverages`, `includes`, `duration`, `location`, `specialRequirements`, `seasonality`, `tags`, `rating`, `reviewCount`; drops the nonexistent `calories` field.
- Confirms `lib/validations/experience.ts` was already reconciled with the `Experience` model — no schema changes needed there.
- Wires `safeParse` + `createValidationErrorResponse` into `app/api/cabins/route.ts`, `app/api/cabins/[id]/route.ts`, `app/api/dining/route.ts`, `app/api/dining/[id]/route.ts`, `app/api/experiences/route.ts`, and `app/api/experiences/[id]/route.ts`, following the pattern in `app/api/bookings/route.ts`.
- Removes the now-redundant inline `discount >= price` checks on the cabin routes and the inline required-fields list / serving-time regex on the dining routes.
- Replaces `sanitizeUpdatePayload()` with Zod validation on these six routes (Zod's default "strip unknown keys" behavior already excludes `$`-operators and arbitrary fields from `validationResult.data`), matching how `app/api/bookings/route.ts` already handles this.

## Why
- Keeps `createXSchema`/`updateXSchema` as independent object schemas rather than `updateXSchema = createXSchema.partial()`. Several fields (`discount`, `status`, `isPopular`, `isAvailable`, `reviewCount`, ...) carry `.default(...)`, and Zod applies defaults even when the key is absent from a `.partial()` parse. A shared-base version of these schemas was caught by a test asserting that a partial update (e.g. `{ _id, name: 'Renamed' }`) doesn't silently reset those fields — this bug already existed in the pre-existing `updateExperienceSchema` (unused until this PR wired it up) and would have been reintroduced in cabin/dining if not caught. `lib/validations/booking.ts` already uses two independent schemas for exactly this reason.

## Test plan
- [x] `pnpm exec tsc --noEmit` (`pnpm check:types`) — clean
- [x] `pnpm test` — 843 passing, 0 failing (50 suites: unit, integration, jsdom)
- [x] `pnpm lint` — no errors
- [x] `pnpm format:check` — clean
- [x] New integration tests (`__tests__/integration/api/{cabins,dining,experiences}.test.ts`, MongoDB Memory Server) cover valid payloads, invalid payloads (missing fields, wrong enums, bad serving time, discount ≥ price), and confirm partial updates don't reset unrelated fields to defaults
- [x] Updated `__tests__/validations/{cabin,dining,experience}.test.ts` for the corrected schemas
- [x] Updated `__tests__/api/{cabins,dining,experiences}.test.ts` (mock-based) for the new validation responses