### PR TITLE
Compute booking pricing server-side instead of trusting client input

### DIFF
--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -369,6 +369,54 @@ describe('Bookings API Routes', () => {
       expect(body.data.extrasPrice).toBe(expectedBreakfastPrice);
       expect(body.data.totalPrice).toBe(800 + expectedBreakfastPrice);
     });
+
+    it('computes pet, parking, early check-in, and late check-out fees from settings, ignoring tampered client amounts', async () => {
+      const cabin = await createTestCabin({ price: 200, discount: 0 });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-08-01',
+          checkOutDate: '2027-08-05', // 4 nights
+          numGuests: 2,
+          extras: {
+            hasPets: true,
+            petFee: 999999,
+            hasParking: true,
+            parkingFee: 999999,
+            hasEarlyCheckIn: true,
+            earlyCheckInFee: 999999,
+            hasLateCheckOut: true,
+            lateCheckOutFee: 999999,
+          },
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      // Default seeded settings: petFee 20/night, parkingFee 10/night
+      // (parking not included), earlyCheckInFee/lateCheckOutFee 50 flat.
+      const expectedPetFee = 20 * 4;
+      const expectedParkingFee = 10 * 4;
+      const expectedEarlyCheckInFee = 50;
+      const expectedLateCheckOutFee = 50;
+      const expectedExtrasPrice =
+        expectedPetFee +
+        expectedParkingFee +
+        expectedEarlyCheckInFee +
+        expectedLateCheckOutFee;
+
+      expect(response.status).toBe(201);
+      expect(body.data.extras.petFee).toBe(expectedPetFee);
+      expect(body.data.extras.parkingFee).toBe(expectedParkingFee);
+      expect(body.data.extras.earlyCheckInFee).toBe(expectedEarlyCheckInFee);
+      expect(body.data.extras.lateCheckOutFee).toBe(expectedLateCheckOutFee);
+      expect(body.data.extrasPrice).toBe(expectedExtrasPrice);
+      expect(body.data.totalPrice).toBe(800 + expectedExtrasPrice);
+    });
   });
 
   describe('PUT /api/bookings', () => {

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -287,6 +287,88 @@ describe('Bookings API Routes', () => {
       expect(response.status).toBe(400);
       expect(body.error).toContain('Number of guests cannot exceed 2');
     });
+
+    it('ignores client-supplied pricing fields and computes them from the cabin price', async () => {
+      // Cabin is $200/night with no discount; 4-night stay should price at $800.
+      const cabin = await createTestCabin({ price: 200, discount: 0 });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-08-01',
+          checkOutDate: '2027-08-05',
+          numGuests: 2,
+          // Tampered pricing fields a malicious client might send.
+          numNights: 999,
+          cabinPrice: 1,
+          extrasPrice: 1,
+          totalPrice: 1,
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.data.numNights).toBe(4);
+      expect(body.data.cabinPrice).toBe(200);
+      expect(body.data.extrasPrice).toBe(0);
+      expect(body.data.totalPrice).toBe(800);
+    });
+
+    it('applies the cabin discount when computing cabinPrice', async () => {
+      const cabin = await createTestCabin({ price: 200, discount: 50 });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-08-01',
+          checkOutDate: '2027-08-05',
+          numGuests: 2,
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.data.cabinPrice).toBe(150);
+      expect(body.data.totalPrice).toBe(600); // 150 * 4 nights
+    });
+
+    it('computes extras pricing from settings, ignoring a client-supplied extras fee amount', async () => {
+      const cabin = await createTestCabin({ price: 200, discount: 0 });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-08-01',
+          checkOutDate: '2027-08-05', // 4 nights
+          numGuests: 2,
+          extras: {
+            hasBreakfast: true,
+            breakfastPrice: 999999, // tampered — should be ignored
+          },
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      // Default seeded settings.breakfastPrice is 15/guest/night.
+      const expectedBreakfastPrice = 15 * 2 * 4;
+
+      expect(response.status).toBe(201);
+      expect(body.data.extras.breakfastPrice).toBe(expectedBreakfastPrice);
+      expect(body.data.extrasPrice).toBe(expectedBreakfastPrice);
+      expect(body.data.totalPrice).toBe(800 + expectedBreakfastPrice);
+    });
   });
 
   describe('PUT /api/bookings', () => {

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -417,6 +417,30 @@ describe('Bookings API Routes', () => {
       expect(body.data.extrasPrice).toBe(expectedExtrasPrice);
       expect(body.data.totalPrice).toBe(800 + expectedExtrasPrice);
     });
+
+    it('returns a 400 (not a 500) for a same-calendar-day stay that only differs by time of day', async () => {
+      const cabin = await createTestCabin({ price: 200, discount: 0 });
+
+      // Passes the Zod refine (checkOutDate > checkInDate as raw
+      // timestamps) but is zero nights once measured in calendar days.
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-08-05T09:00:00.000Z',
+          checkOutDate: '2027-08-05T15:00:00.000Z',
+          numGuests: 2,
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('checkOutDate');
+    });
   });
 
   describe('PUT /api/bookings', () => {

--- a/__tests__/unit/lib/booking-pricing.test.ts
+++ b/__tests__/unit/lib/booking-pricing.test.ts
@@ -1,4 +1,7 @@
-import { calculateBookingPricing } from '@/lib/booking-pricing';
+import {
+  BookingPricingError,
+  calculateBookingPricing,
+} from '@/lib/booking-pricing';
 
 const baseCabin = { price: 200, discount: 0, extraGuestFee: 0 };
 const baseSettings = {
@@ -60,7 +63,7 @@ describe('calculateBookingPricing', () => {
     expect(result.cabinPrice).toBe(200);
   });
 
-  it('throws when checkOutDate is not after checkInDate', () => {
+  it('throws a BookingPricingError when checkOutDate is not after checkInDate', () => {
     expect(() =>
       calculateBookingPricing({
         cabin: baseCabin,
@@ -69,10 +72,24 @@ describe('calculateBookingPricing', () => {
         checkOutDate: new Date('2027-08-05'),
         numGuests: 2,
       })
-    ).toThrow(/checkOutDate/);
+    ).toThrow(BookingPricingError);
   });
 
-  it('throws when numGuests is less than 1', () => {
+  it('throws a BookingPricingError for a same-calendar-day stay even when the raw timestamps differ', () => {
+    // checkOutDate is later in the day but on the same calendar date —
+    // differenceInCalendarDays yields 0 nights.
+    expect(() =>
+      calculateBookingPricing({
+        cabin: baseCabin,
+        settings: baseSettings,
+        checkInDate: new Date('2027-08-05T09:00:00Z'),
+        checkOutDate: new Date('2027-08-05T15:00:00Z'),
+        numGuests: 2,
+      })
+    ).toThrow(BookingPricingError);
+  });
+
+  it('throws a BookingPricingError when numGuests is less than 1', () => {
     expect(() =>
       calculateBookingPricing({
         cabin: baseCabin,
@@ -81,7 +98,7 @@ describe('calculateBookingPricing', () => {
         checkOutDate: new Date('2027-08-05'),
         numGuests: 0,
       })
-    ).toThrow(/numGuests/);
+    ).toThrow(BookingPricingError);
   });
 
   it('returns zero extras pricing and totalPrice equal to cabinPrice*nights when no extras are selected', () => {

--- a/__tests__/unit/lib/booking-pricing.test.ts
+++ b/__tests__/unit/lib/booking-pricing.test.ts
@@ -36,7 +36,7 @@ describe('calculateBookingPricing', () => {
     expect(result.totalPrice).toBe(150 * 4);
   });
 
-  it('ignores a zero/negative discount and uses the full cabin price', () => {
+  it('ignores a zero discount and uses the full cabin price', () => {
     const result = calculateBookingPricing({
       cabin: { price: 200, discount: 0, extraGuestFee: 0 },
       settings: baseSettings,
@@ -46,6 +46,42 @@ describe('calculateBookingPricing', () => {
     });
 
     expect(result.cabinPrice).toBe(200);
+  });
+
+  it('ignores a negative discount and uses the full cabin price', () => {
+    const result = calculateBookingPricing({
+      cabin: { price: 200, discount: -10, extraGuestFee: 0 },
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 2,
+    });
+
+    expect(result.cabinPrice).toBe(200);
+  });
+
+  it('throws when checkOutDate is not after checkInDate', () => {
+    expect(() =>
+      calculateBookingPricing({
+        cabin: baseCabin,
+        settings: baseSettings,
+        checkInDate: new Date('2027-08-05'),
+        checkOutDate: new Date('2027-08-05'),
+        numGuests: 2,
+      })
+    ).toThrow(/checkOutDate/);
+  });
+
+  it('throws when numGuests is less than 1', () => {
+    expect(() =>
+      calculateBookingPricing({
+        cabin: baseCabin,
+        settings: baseSettings,
+        checkInDate: new Date('2027-08-01'),
+        checkOutDate: new Date('2027-08-05'),
+        numGuests: 0,
+      })
+    ).toThrow(/numGuests/);
   });
 
   it('returns zero extras pricing and totalPrice equal to cabinPrice*nights when no extras are selected', () => {
@@ -147,6 +183,19 @@ describe('calculateBookingPricing', () => {
     });
 
     expect(result.extrasPrice).toBe(30 * 2 * 4);
+  });
+
+  it('charges no extra-guest fee for a single guest even when the cabin has one configured', () => {
+    const result = calculateBookingPricing({
+      cabin: { price: 200, discount: 0, extraGuestFee: 30 },
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 1,
+      extras: {},
+    });
+
+    expect(result.extrasPrice).toBe(0);
   });
 
   it('sums cabinPrice*nights and all extras into totalPrice', () => {

--- a/__tests__/unit/lib/booking-pricing.test.ts
+++ b/__tests__/unit/lib/booking-pricing.test.ts
@@ -1,0 +1,192 @@
+import { calculateBookingPricing } from '@/lib/booking-pricing';
+
+const baseCabin = { price: 200, discount: 0, extraGuestFee: 0 };
+const baseSettings = {
+  breakfastPrice: 15,
+  petFee: 25,
+  parkingFee: 10,
+  parkingIncluded: false,
+  earlyCheckInFee: 20,
+  lateCheckOutFee: 20,
+};
+
+describe('calculateBookingPricing', () => {
+  it('computes numNights from the check-in/check-out range', () => {
+    const result = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 2,
+    });
+
+    expect(result.numNights).toBe(4);
+  });
+
+  it('prices the cabin per night using the discounted price', () => {
+    const result = calculateBookingPricing({
+      cabin: { price: 200, discount: 50, extraGuestFee: 0 },
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 2,
+    });
+
+    expect(result.cabinPrice).toBe(150);
+    expect(result.totalPrice).toBe(150 * 4);
+  });
+
+  it('ignores a zero/negative discount and uses the full cabin price', () => {
+    const result = calculateBookingPricing({
+      cabin: { price: 200, discount: 0, extraGuestFee: 0 },
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 2,
+    });
+
+    expect(result.cabinPrice).toBe(200);
+  });
+
+  it('returns zero extras pricing and totalPrice equal to cabinPrice*nights when no extras are selected', () => {
+    const result = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 2,
+    });
+
+    expect(result.extrasPrice).toBe(0);
+    expect(result.totalPrice).toBe(800);
+    expect(result.extras).toEqual({
+      hasBreakfast: false,
+      breakfastPrice: 0,
+      hasPets: false,
+      petFee: 0,
+      hasParking: false,
+      parkingFee: 0,
+      hasEarlyCheckIn: false,
+      earlyCheckInFee: 0,
+      hasLateCheckOut: false,
+      lateCheckOutFee: 0,
+    });
+  });
+
+  it('prices breakfast per guest per night', () => {
+    const result = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'), // 4 nights
+      numGuests: 3,
+      extras: { hasBreakfast: true },
+    });
+
+    expect(result.extras.breakfastPrice).toBe(15 * 3 * 4);
+    expect(result.extrasPrice).toBe(15 * 3 * 4);
+  });
+
+  it('prices the pet fee per night', () => {
+    const result = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'), // 4 nights
+      numGuests: 2,
+      extras: { hasPets: true },
+    });
+
+    expect(result.extras.petFee).toBe(25 * 4);
+  });
+
+  it('prices the parking fee per night only when parking is not already included', () => {
+    const withoutIncluded = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: { ...baseSettings, parkingIncluded: false },
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'), // 4 nights
+      numGuests: 2,
+      extras: { hasParking: true },
+    });
+    expect(withoutIncluded.extras.parkingFee).toBe(10 * 4);
+
+    const withIncluded = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: { ...baseSettings, parkingIncluded: true },
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 2,
+      extras: { hasParking: true },
+    });
+    expect(withIncluded.extras.parkingFee).toBe(0);
+  });
+
+  it('charges flat early check-in and late check-out fees regardless of stay length', () => {
+    const result = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-10'), // 9 nights
+      numGuests: 2,
+      extras: { hasEarlyCheckIn: true, hasLateCheckOut: true },
+    });
+
+    expect(result.extras.earlyCheckInFee).toBe(20);
+    expect(result.extras.lateCheckOutFee).toBe(20);
+  });
+
+  it('charges an extra-guest fee per additional guest per night when the cabin has one', () => {
+    const result = calculateBookingPricing({
+      cabin: { price: 200, discount: 0, extraGuestFee: 30 },
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'), // 4 nights
+      numGuests: 3, // 2 extra guests beyond the first
+      extras: {},
+    });
+
+    expect(result.extrasPrice).toBe(30 * 2 * 4);
+  });
+
+  it('sums cabinPrice*nights and all extras into totalPrice', () => {
+    const result = calculateBookingPricing({
+      cabin: { price: 200, discount: 20, extraGuestFee: 10 },
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-04'), // 3 nights
+      numGuests: 2,
+      extras: { hasBreakfast: true, hasPets: true },
+    });
+
+    const expectedCabinPrice = 180; // 200 - 20
+    const expectedExtraGuestFee = 10 * 1 * 3;
+    const expectedBreakfast = 15 * 2 * 3;
+    const expectedPetFee = 25 * 3;
+    const expectedExtrasPrice =
+      expectedExtraGuestFee + expectedBreakfast + expectedPetFee;
+
+    expect(result.cabinPrice).toBe(expectedCabinPrice);
+    expect(result.extrasPrice).toBe(expectedExtrasPrice);
+    expect(result.totalPrice).toBe(
+      expectedCabinPrice * 3 + expectedExtrasPrice
+    );
+  });
+
+  it('ignores any client-supplied fee values on the extras selection', () => {
+    const result = calculateBookingPricing({
+      cabin: baseCabin,
+      settings: baseSettings,
+      checkInDate: new Date('2027-08-01'),
+      checkOutDate: new Date('2027-08-05'),
+      numGuests: 2,
+      extras: {
+        hasBreakfast: true,
+        // @ts-expect-error - simulating a tampered client payload
+        breakfastPrice: 999999,
+      },
+    });
+
+    expect(result.extras.breakfastPrice).toBe(15 * 2 * 4);
+  });
+});

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/api-utils';
 import { differenceInCalendarDays } from 'date-fns';
 import mongoose from 'mongoose';
+import { calculateBookingPricing } from '@/lib/booking-pricing';
 import { getClerkUsersBatch, searchClerkUsers } from '@/lib/clerk-users';
 import { VALID_TRANSITIONS } from '@/lib/config';
 import { logger } from '@/lib/logger';
@@ -241,9 +242,19 @@ export async function POST(request: NextRequest) {
     const settings = await Settings.getSettings();
     const { checkInDate, checkOutDate, numGuests, extras } =
       validationResult.data;
-    const numNights = Math.ceil(
-      (checkOutDate.getTime() - checkInDate.getTime()) / (1000 * 60 * 60 * 24)
-    );
+
+    // Recompute every price-derived field from the trusted cabin/settings
+    // documents rather than trusting the client-supplied numNights,
+    // cabinPrice, extrasPrice, and totalPrice (see issue #109).
+    const pricing = calculateBookingPricing({
+      cabin,
+      settings,
+      checkInDate,
+      checkOutDate,
+      numGuests,
+      extras,
+    });
+    const { numNights } = pricing;
     const effectiveMinNights = Math.max(
       settings.minBookingLength,
       cabin.minNights ?? 0
@@ -302,7 +313,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const booking = await Booking.create(validationResult.data);
+    const booking = await Booking.create({
+      ...validationResult.data,
+      numNights: pricing.numNights,
+      cabinPrice: pricing.cabinPrice,
+      extrasPrice: pricing.extrasPrice,
+      totalPrice: pricing.totalPrice,
+      extras: pricing.extras,
+    });
 
     // Populate the response
     const populatedBooking = await Booking.findById(booking._id).populate(

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -6,7 +6,10 @@ import {
 } from '@/lib/api-utils';
 import { differenceInCalendarDays } from 'date-fns';
 import mongoose from 'mongoose';
-import { calculateBookingPricing } from '@/lib/booking-pricing';
+import {
+  BookingPricingError,
+  calculateBookingPricing,
+} from '@/lib/booking-pricing';
 import { getClerkUsersBatch, searchClerkUsers } from '@/lib/clerk-users';
 import { VALID_TRANSITIONS } from '@/lib/config';
 import { logger } from '@/lib/logger';
@@ -349,6 +352,17 @@ export async function POST(request: NextRequest) {
       { status: 201 }
     );
   } catch (error: unknown) {
+    // A same-calendar-day booking can pass the Zod refine (which only
+    // compares raw timestamps) but yield zero nights once
+    // calculateBookingPricing measures calendar days — surface that as a
+    // 400, not a generic server error.
+    if (error instanceof BookingPricingError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 400 }
+      );
+    }
+
     // Handle validation errors
     if (isMongooseValidationError(error)) {
       logger.warn(

--- a/lib/booking-pricing.ts
+++ b/lib/booking-pricing.ts
@@ -1,0 +1,127 @@
+import { differenceInCalendarDays } from 'date-fns';
+
+export interface BookingPricingCabin {
+  price: number;
+  discount: number;
+  extraGuestFee?: number;
+}
+
+export interface BookingPricingSettings {
+  breakfastPrice: number;
+  petFee: number;
+  parkingFee: number;
+  parkingIncluded: boolean;
+  earlyCheckInFee: number;
+  lateCheckOutFee: number;
+}
+
+export interface BookingPricingExtrasSelection {
+  hasBreakfast?: boolean;
+  hasPets?: boolean;
+  hasParking?: boolean;
+  hasEarlyCheckIn?: boolean;
+  hasLateCheckOut?: boolean;
+}
+
+export interface BookingPricingInput {
+  cabin: BookingPricingCabin;
+  settings: BookingPricingSettings;
+  checkInDate: Date;
+  checkOutDate: Date;
+  numGuests: number;
+  extras?: BookingPricingExtrasSelection;
+}
+
+export interface BookingPricingResult {
+  numNights: number;
+  cabinPrice: number;
+  extrasPrice: number;
+  totalPrice: number;
+  extras: {
+    hasBreakfast: boolean;
+    breakfastPrice: number;
+    hasPets: boolean;
+    petFee: number;
+    hasParking: boolean;
+    parkingFee: number;
+    hasEarlyCheckIn: boolean;
+    earlyCheckInFee: number;
+    hasLateCheckOut: boolean;
+    lateCheckOutFee: number;
+  };
+}
+
+/**
+ * Recomputes every price-derived booking field from trusted server data
+ * (the cabin and settings documents) instead of client input. Only the
+ * boolean extras selections are taken from the caller — every fee amount
+ * is looked up from `settings`/`cabin` so a tampered request body can't
+ * influence the price actually charged.
+ */
+export function calculateBookingPricing({
+  cabin,
+  settings,
+  checkInDate,
+  checkOutDate,
+  numGuests,
+  extras,
+}: BookingPricingInput): BookingPricingResult {
+  const numNights = differenceInCalendarDays(checkOutDate, checkInDate);
+
+  const cabinPrice =
+    cabin.discount > 0 ? cabin.price - cabin.discount : cabin.price;
+
+  const hasBreakfast = extras?.hasBreakfast ?? false;
+  const hasPets = extras?.hasPets ?? false;
+  const hasParking = extras?.hasParking ?? false;
+  const hasEarlyCheckIn = extras?.hasEarlyCheckIn ?? false;
+  const hasLateCheckOut = extras?.hasLateCheckOut ?? false;
+
+  const breakfastPrice = hasBreakfast
+    ? settings.breakfastPrice * numGuests * numNights
+    : 0;
+
+  const extraGuestFee =
+    numGuests > 1 && (cabin.extraGuestFee ?? 0) > 0
+      ? (numGuests - 1) * (cabin.extraGuestFee ?? 0) * numNights
+      : 0;
+
+  const petFee = hasPets ? settings.petFee * numNights : 0;
+
+  const parkingFee =
+    hasParking && !settings.parkingIncluded
+      ? settings.parkingFee * numNights
+      : 0;
+
+  const earlyCheckInFee = hasEarlyCheckIn ? settings.earlyCheckInFee : 0;
+  const lateCheckOutFee = hasLateCheckOut ? settings.lateCheckOutFee : 0;
+
+  const extrasPrice =
+    breakfastPrice +
+    extraGuestFee +
+    petFee +
+    parkingFee +
+    earlyCheckInFee +
+    lateCheckOutFee;
+
+  const totalPrice = cabinPrice * numNights + extrasPrice;
+
+  return {
+    numNights,
+    cabinPrice,
+    extrasPrice,
+    totalPrice,
+    extras: {
+      hasBreakfast,
+      breakfastPrice,
+      hasPets,
+      petFee,
+      hasParking,
+      parkingFee,
+      hasEarlyCheckIn,
+      earlyCheckInFee,
+      hasLateCheckOut,
+      lateCheckOutFee,
+    },
+  };
+}

--- a/lib/booking-pricing.ts
+++ b/lib/booking-pricing.ts
@@ -1,5 +1,21 @@
 import { differenceInCalendarDays } from 'date-fns';
 
+/**
+ * Thrown when calculateBookingPricing() is given inputs that can't yield a
+ * sane price (e.g. a non-positive stay length). Callers should catch this
+ * distinctly and surface it as a 400 rather than a generic server error —
+ * it signals bad input, not a server fault.
+ */
+export class BookingPricingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BookingPricingError';
+    // Restore the prototype chain — TS compiles `extends Error` down to
+    // ES5 (tsconfig `target`), which otherwise breaks `instanceof` checks.
+    Object.setPrototypeOf(this, BookingPricingError.prototype);
+  }
+}
+
 export interface BookingPricingCabin {
   price: number;
   discount: number;
@@ -68,10 +84,12 @@ export function calculateBookingPricing({
 }: BookingPricingInput): BookingPricingResult {
   const numNights = differenceInCalendarDays(checkOutDate, checkInDate);
   if (numNights < 1) {
-    throw new Error('checkOutDate must be at least one day after checkInDate');
+    throw new BookingPricingError(
+      'checkOutDate must be at least one day after checkInDate'
+    );
   }
   if (numGuests < 1) {
-    throw new Error('numGuests must be at least 1');
+    throw new BookingPricingError('numGuests must be at least 1');
   }
 
   const cabinPrice =

--- a/lib/booking-pricing.ts
+++ b/lib/booking-pricing.ts
@@ -67,6 +67,12 @@ export function calculateBookingPricing({
   extras,
 }: BookingPricingInput): BookingPricingResult {
   const numNights = differenceInCalendarDays(checkOutDate, checkInDate);
+  if (numNights < 1) {
+    throw new Error('checkOutDate must be at least one day after checkInDate');
+  }
+  if (numGuests < 1) {
+    throw new Error('numGuests must be at least 1');
+  }
 
   const cabinPrice =
     cabin.discount > 0 ? cabin.price - cabin.discount : cabin.price;

--- a/lib/validations/booking.ts
+++ b/lib/validations/booking.ts
@@ -46,9 +46,10 @@ export const createBookingSchema = z
     checkInDate: z.coerce.date(),
     checkOutDate: z.coerce.date(),
     numGuests: z.number().int().min(1, 'At least 1 guest required').max(50),
-    // numNights, cabinPrice, and totalPrice are optional here because the API
-    // route calculates them server-side. Mongoose requires them, so they must
-    // be set before save — but callers don't need to provide them up front.
+    // numNights, cabinPrice, extrasPrice, and totalPrice are optional here
+    // because the API route recomputes them server-side from the cabin and
+    // settings documents (see calculateBookingPricing in lib/booking-pricing.ts)
+    // — any client-supplied values for these fields are ignored on create.
     numNights: z.number().int().min(1).optional(),
     status: bookingStatusSchema.optional().default('unconfirmed'),
     cabinPrice: z.number().min(0).optional(),


### PR DESCRIPTION
Closes #109.

## Summary
- Adds `calculateBookingPricing()` in `lib/booking-pricing.ts` — a pure function that derives `numNights` from the check-in/check-out range, `cabinPrice` from the cabin's `price`/`discount`, and each extras fee (`breakfastPrice`, `petFee`, `parkingFee`, `earlyCheckInFee`, `lateCheckOutFee`, plus the cabin's `extraGuestFee`) from the `Settings` document. Only the boolean extras selections (`hasBreakfast`, `hasPets`, etc.) are taken from the caller; it throws a `BookingPricingError` if `checkOutDate` isn't after `checkInDate` (measured in calendar days) or `numGuests < 1`.
- `POST /api/bookings` (`app/api/bookings/route.ts`) now calls `calculateBookingPricing()` and overrides `numNights`, `cabinPrice`, `extrasPrice`, `totalPrice`, and `extras` with the computed values before `Booking.create()` — any client-supplied values for these fields are ignored.
- The route's own `numNights` calculation (previously `Math.ceil` on a millisecond diff, inconsistent with the `differenceInCalendarDays` used by the `Booking` pre-save hook and the `PUT` handler) is replaced by the single `calculateBookingPricing()` computation, so validation, pricing, and the persisted value can no longer drift apart.
- `BookingPricingError` is caught explicitly in the `POST` handler and returned as a 400 with the underlying message — needed because `createBookingSchema`'s Zod refine compares raw timestamps while `calculateBookingPricing` measures calendar days, so a same-calendar-day request (later check-out time, same date) can pass Zod but still get rejected by the pricing calculation; without this it fell through to the generic catch-all as a confusing 500.
- Updates the misleading comment in `lib/validations/booking.ts` (`createBookingSchema`) to point at `calculateBookingPricing` and state explicitly that client-supplied pricing values are ignored.

## Why
The suggested fix in #109 scoped extras pricing to "breakfast/pet/parking fees," but the `Booking` model and the existing client form (`hooks/useBookingForm.ts`) also price `earlyCheckInFee`, `lateCheckOutFee`, and a per-guest `extraGuestFee` from the cabin. Leaving those out would still let a tampered request set an arbitrary `extras.earlyCheckInFee`/`lateCheckOutFee` display value, so `calculateBookingPricing()` recomputes all of them from `Settings`/`Cabin`, matching the same trust boundary already established for the other three fields.

## Out of scope (deferred)
- `PUT /api/bookings` has the identical trust gap for `cabinPrice`/`extrasPrice`/`totalPrice` — an existing test (`recalculates remainingAmount when totalPrice changes`) shows it currently supports a direct client-supplied `totalPrice`, which may be an intentional manual-override admin workflow rather than a bug, so it needs a product decision before changing. Tracked in #122.
- `depositAmount` is still accepted from the client on both `POST` and `PUT` without validation against `settings.depositPercentage`, so `remainingAmount` can still be manipulated independently of `totalPrice`. Also tracked in #122.
- The pricing formulas in `lib/booking-pricing.ts` now exist in three places (this file, `hooks/useBookingForm.ts`, `app/api/cron/seed/route.ts`). Not consolidating in this PR to avoid touching the seed script and client form UX in a security-fix PR.

## Test plan
- [x] `pnpm test:unit -- booking-pricing` — 16/16 passing (per-night cabin pricing, discount handling incl. negative discount, each extras fee, extra-guest fee incl. single-guest edge case, tampered client fee values ignored, and `BookingPricingError` thrown — incl. a same-calendar-day/different-time case — for both guard clauses)
- [x] `pnpm test:integration -- bookings.test` — 26/26 passing, including cases that tamper with `numNights`/`cabinPrice`/`extrasPrice`/`totalPrice`, the cabin discount, every individual extras fee (breakfast, pets, parking, early check-in, late check-out) through the real POST route, and that a same-calendar-day/different-time request gets a clean 400 rather than a 500
- [x] `pnpm ci:check` — format check clean, lint clean, `890 passing` across 51 suites
- [x] `pnpm check:types` — clean