### PR TITLE
Lock down PUT /api/bookings pricing fields to server-computed values

### DIFF
--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -629,7 +629,7 @@ describe('Bookings API Routes', () => {
       expect(body.data.totalPrice).toBe(1400); // cabin price 200 * 7 nights
     });
 
-    it('ignores a client-supplied totalPrice/cabinPrice/extrasPrice/numNights and keeps the existing values', async () => {
+    it('ignores a client-supplied totalPrice/cabinPrice/extrasPrice/numNights/remainingAmount and keeps the existing values', async () => {
       const cabin = await createTestCabin();
       const booking = await createTestBooking(cabin._id, {
         numNights: 3,
@@ -647,6 +647,10 @@ describe('Bookings API Routes', () => {
           cabinPrice: 1,
           extrasPrice: 1,
           totalPrice: 1,
+          // A booking with totalPrice 600 / depositAmount 200 has a true
+          // remainingAmount of 400 — claiming 0 here would make it look
+          // fully paid with no actual payment recorded.
+          remainingAmount: 0,
         },
       });
 
@@ -658,8 +662,7 @@ describe('Bookings API Routes', () => {
       expect(body.data.cabinPrice).toBe(600);
       expect(body.data.extrasPrice).toBe(0);
       expect(body.data.totalPrice).toBe(600);
-      // remainingAmount must not have been recalculated off the tampered price
-      expect(body.data.remainingAmount).toBe(400); // 600 - 200
+      expect(body.data.remainingAmount).toBe(400); // 600 - 200, not the tampered 0
     });
 
     it('recomputes totalPrice and remainingAmount from the cabin price when numGuests changes', async () => {

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -629,9 +629,10 @@ describe('Bookings API Routes', () => {
       expect(body.data.totalPrice).toBe(1400); // cabin price 200 * 7 nights
     });
 
-    it('ignores a client-supplied totalPrice/cabinPrice/extrasPrice and keeps the existing price', async () => {
+    it('ignores a client-supplied totalPrice/cabinPrice/extrasPrice/numNights and keeps the existing values', async () => {
       const cabin = await createTestCabin();
       const booking = await createTestBooking(cabin._id, {
+        numNights: 3,
         cabinPrice: 600,
         extrasPrice: 0,
         totalPrice: 600,
@@ -642,6 +643,7 @@ describe('Bookings API Routes', () => {
         method: 'PUT',
         body: {
           _id: booking._id.toString(),
+          numNights: 999,
           cabinPrice: 1,
           extrasPrice: 1,
           totalPrice: 1,
@@ -652,6 +654,7 @@ describe('Bookings API Routes', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
+      expect(body.data.numNights).toBe(3);
       expect(body.data.cabinPrice).toBe(600);
       expect(body.data.extrasPrice).toBe(0);
       expect(body.data.totalPrice).toBe(600);

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -693,6 +693,131 @@ describe('Bookings API Routes', () => {
       expect(body.data.totalPrice).toBe(660); // 600 + 60
       expect(body.data.remainingAmount).toBe(560); // 660 - 100
     });
+
+    it('ignores tampered extras.*Fee values and computes fees from settings', async () => {
+      const cabin = await createTestCabin({ price: 200 });
+      const booking = await createTestBooking(cabin._id, {
+        checkInDate: new Date('2027-06-01'),
+        checkOutDate: new Date('2027-06-05'), // 4 nights
+        numNights: 4,
+        cabinPrice: 800,
+        extrasPrice: 0,
+        totalPrice: 800,
+      });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'PUT',
+        body: {
+          _id: booking._id.toString(),
+          extras: {
+            hasBreakfast: true,
+            breakfastPrice: 999999, // tampered — should be ignored
+            hasPets: true,
+            petFee: 999999,
+            hasParking: true,
+            parkingFee: 999999,
+          },
+        },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      // Default seeded settings: breakfastPrice 15/guest/night, petFee
+      // 20/night, parkingFee 10/night (not included).
+      const expectedBreakfastPrice = 15 * 2 * 4; // numGuests(2) * 4 nights
+      const expectedPetFee = 20 * 4;
+      const expectedParkingFee = 10 * 4;
+      const expectedExtrasPrice =
+        expectedBreakfastPrice + expectedPetFee + expectedParkingFee;
+
+      expect(response.status).toBe(200);
+      expect(body.data.extras.breakfastPrice).toBe(expectedBreakfastPrice);
+      expect(body.data.extras.petFee).toBe(expectedPetFee);
+      expect(body.data.extras.parkingFee).toBe(expectedParkingFee);
+      expect(body.data.extrasPrice).toBe(expectedExtrasPrice);
+      expect(body.data.totalPrice).toBe(800 + expectedExtrasPrice);
+    });
+
+    it('recomputes cabinPrice and totalPrice from the new cabin when cabin changes', async () => {
+      const originalCabin = await createTestCabin({ price: 200 });
+      const newCabin = await createTestCabin({
+        name: 'Deluxe Cabin',
+        price: 350,
+      });
+      const booking = await createTestBooking(originalCabin._id, {
+        numNights: 3,
+        cabinPrice: 200,
+        extrasPrice: 0,
+        totalPrice: 600,
+      });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'PUT',
+        body: {
+          _id: booking._id.toString(),
+          cabin: newCabin._id.toString(),
+        },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data.cabinPrice).toBe(350);
+      expect(body.data.totalPrice).toBe(1050); // 350 * 3 nights
+    });
+
+    it('recomputes remainingAmount from the existing totalPrice when only depositAmount changes', async () => {
+      const cabin = await createTestCabin();
+      const booking = await createTestBooking(cabin._id, {
+        totalPrice: 600,
+        depositAmount: 0,
+      });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'PUT',
+        body: {
+          _id: booking._id.toString(),
+          depositAmount: 300,
+        },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      // totalPrice must be untouched — only depositAmount changed
+      expect(body.data.totalPrice).toBe(600);
+      expect(body.data.remainingAmount).toBe(300); // 600 - 300
+    });
+
+    it('returns a 400 (not a 500) when only checkOutDate changes to the same calendar day as the existing checkInDate', async () => {
+      const cabin = await createTestCabin({ price: 200 });
+      const booking = await createTestBooking(cabin._id, {
+        checkInDate: new Date('2027-08-05T09:00:00.000Z'),
+        checkOutDate: new Date('2027-08-08T09:00:00.000Z'),
+        numNights: 3,
+      });
+
+      // Only checkOutDate is submitted, so updateBookingSchema's refine
+      // (which only compares checkInDate/checkOutDate when both are present)
+      // never fires — calculateBookingPricing must reject this itself.
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'PUT',
+        body: {
+          _id: booking._id.toString(),
+          checkOutDate: '2027-08-05T15:00:00.000Z',
+        },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('checkOutDate');
+    });
   });
 
   describe('DELETE /api/bookings', () => {

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -626,11 +626,14 @@ describe('Bookings API Routes', () => {
 
       expect(response.status).toBe(200);
       expect(body.data.numNights).toBe(7); // June 1 to June 8
+      expect(body.data.totalPrice).toBe(1400); // cabin price 200 * 7 nights
     });
 
-    it('recalculates remainingAmount when totalPrice changes', async () => {
+    it('ignores a client-supplied totalPrice/cabinPrice/extrasPrice and keeps the existing price', async () => {
       const cabin = await createTestCabin();
       const booking = await createTestBooking(cabin._id, {
+        cabinPrice: 600,
+        extrasPrice: 0,
         totalPrice: 600,
         depositAmount: 200,
       });
@@ -639,7 +642,9 @@ describe('Bookings API Routes', () => {
         method: 'PUT',
         body: {
           _id: booking._id.toString(),
-          totalPrice: 1000,
+          cabinPrice: 1,
+          extrasPrice: 1,
+          totalPrice: 1,
         },
       });
 
@@ -647,7 +652,46 @@ describe('Bookings API Routes', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body.data.remainingAmount).toBe(800); // 1000 - 200
+      expect(body.data.cabinPrice).toBe(600);
+      expect(body.data.extrasPrice).toBe(0);
+      expect(body.data.totalPrice).toBe(600);
+      // remainingAmount must not have been recalculated off the tampered price
+      expect(body.data.remainingAmount).toBe(400); // 600 - 200
+    });
+
+    it('recomputes totalPrice and remainingAmount from the cabin price when numGuests changes', async () => {
+      const cabin = await createTestCabin({
+        price: 200,
+        capacity: 4,
+        extraGuestFee: 20,
+      });
+      const booking = await createTestBooking(cabin._id, {
+        numGuests: 1,
+        cabinPrice: 200,
+        extrasPrice: 0,
+        totalPrice: 600, // 200 * 3 nights
+        depositAmount: 100,
+      });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'PUT',
+        body: {
+          _id: booking._id.toString(),
+          numGuests: 2,
+          // A tampered totalPrice sent alongside the legitimate change must
+          // still be ignored in favor of the server-computed value.
+          totalPrice: 1,
+        },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      // extraGuestFee: (2 - 1) * 20 * 3 nights = 60
+      expect(body.data.extrasPrice).toBe(60);
+      expect(body.data.totalPrice).toBe(660); // 600 + 60
+      expect(body.data.remainingAmount).toBe(560); // 660 - 100
     });
   });
 

--- a/__tests__/unit/lib/booking-pricing.test.ts
+++ b/__tests__/unit/lib/booking-pricing.test.ts
@@ -101,6 +101,32 @@ describe('calculateBookingPricing', () => {
     ).toThrow(BookingPricingError);
   });
 
+  it('throws a BookingPricingError instead of returning NaN pricing for an invalid date', () => {
+    // NaN comparisons are always false, so `numNights < 1` alone would not
+    // catch this — Number.isFinite() must reject it explicitly.
+    expect(() =>
+      calculateBookingPricing({
+        cabin: baseCabin,
+        settings: baseSettings,
+        checkInDate: new Date('invalid'),
+        checkOutDate: new Date('2027-08-05'),
+        numGuests: 2,
+      })
+    ).toThrow(BookingPricingError);
+  });
+
+  it('throws a BookingPricingError instead of returning NaN pricing for a NaN numGuests', () => {
+    expect(() =>
+      calculateBookingPricing({
+        cabin: baseCabin,
+        settings: baseSettings,
+        checkInDate: new Date('2027-08-01'),
+        checkOutDate: new Date('2027-08-05'),
+        numGuests: NaN,
+      })
+    ).toThrow(BookingPricingError);
+  });
+
   it('returns zero extras pricing and totalPrice equal to cabinPrice*nights when no extras are selected', () => {
     const result = calculateBookingPricing({
       cabin: baseCabin,

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -429,6 +429,7 @@ export async function PUT(request: NextRequest) {
     delete updateData.cabinPrice;
     delete updateData.extrasPrice;
     delete updateData.totalPrice;
+    delete updateData.remainingAmount;
 
     // Fetch the existing booking first so auto-timestamping can check prior state
     const existingBooking = await Booking.findById(_id);

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -4,7 +4,6 @@ import {
   parsePagination,
   requireApiAuth,
 } from '@/lib/api-utils';
-import { differenceInCalendarDays } from 'date-fns';
 import mongoose from 'mongoose';
 import {
   BookingPricingError,
@@ -422,6 +421,14 @@ export async function PUT(request: NextRequest) {
 
     const { _id, ...updateData } = validationResult.data;
 
+    // Never trust client-supplied pricing fields on update — same trust
+    // boundary as POST (see calculateBookingPricing in lib/booking-pricing.ts
+    // and issue #122). These are only ever set below, recomputed from the
+    // cabin/settings documents when a pricing-relevant field actually changes.
+    delete updateData.cabinPrice;
+    delete updateData.extrasPrice;
+    delete updateData.totalPrice;
+
     // Fetch the existing booking first so auto-timestamping can check prior state
     const existingBooking = await Booking.findById(_id);
     if (!existingBooking) {
@@ -538,6 +545,7 @@ export async function PUT(request: NextRequest) {
       const checkIn = updateData.checkInDate || existingBooking.checkInDate;
       const checkOut = updateData.checkOutDate || existingBooking.checkOutDate;
       const numGuests = updateData.numGuests ?? existingBooking.numGuests;
+      const extras = updateData.extras ?? existingBooking.extras;
 
       // Fetch cabin for minNights check
       const cabinId = updateData.cabin || existingBooking.cabin;
@@ -548,10 +556,20 @@ export async function PUT(request: NextRequest) {
           { status: 404 }
         );
       }
-      const numNights = Math.ceil(
-        (new Date(checkOut).getTime() - new Date(checkIn).getTime()) /
-          (1000 * 60 * 60 * 24)
-      );
+
+      // Recompute every price-derived field from the trusted cabin/settings
+      // documents rather than trusting client-supplied cabinPrice, extrasPrice,
+      // totalPrice, and extras.*Fee values (see issue #122 — same trust
+      // boundary as POST).
+      const pricing = calculateBookingPricing({
+        cabin: cabinForValidation,
+        settings,
+        checkInDate: new Date(checkIn),
+        checkOutDate: new Date(checkOut),
+        numGuests,
+        extras,
+      });
+
       const effectiveMinNights = Math.max(
         settings.minBookingLength,
         cabinForValidation.minNights ?? 0
@@ -561,7 +579,7 @@ export async function PUT(request: NextRequest) {
         cabinForValidation.capacity
       );
 
-      if (numNights < effectiveMinNights) {
+      if (pricing.numNights < effectiveMinNights) {
         return NextResponse.json(
           {
             success: false,
@@ -570,7 +588,7 @@ export async function PUT(request: NextRequest) {
           { status: 400 }
         );
       }
-      if (numNights > settings.maxBookingLength) {
+      if (pricing.numNights > settings.maxBookingLength) {
         return NextResponse.json(
           {
             success: false,
@@ -588,13 +606,18 @@ export async function PUT(request: NextRequest) {
           { status: 400 }
         );
       }
-      const extras = updateData.extras ?? existingBooking.extras;
-      if (extras?.hasPets && !settings.allowPets) {
+      if (pricing.extras.hasPets && !settings.allowPets) {
         return NextResponse.json(
           { success: false, error: 'Pets are not allowed' },
           { status: 400 }
         );
       }
+
+      updateData.numNights = pricing.numNights;
+      updateData.cabinPrice = pricing.cabinPrice;
+      updateData.extrasPrice = pricing.extrasPrice;
+      updateData.totalPrice = pricing.totalPrice;
+      updateData.extras = pricing.extras;
     }
 
     // Only check for date overlaps when dates or cabin actually changed
@@ -634,20 +657,10 @@ export async function PUT(request: NextRequest) {
       }
     }
 
-    // Manually recalculate fields that pre-save hooks would normally handle,
-    // since findByIdAndUpdate bypasses Mongoose pre-save middleware.
-    // Only recalculate when the relevant fields actually changed to avoid
-    // silent overwrites (e.g. differenceInCalendarDays vs Math.ceil across DST).
-    if (checkInChanged || checkOutChanged) {
-      const effectiveCheckIn =
-        updateData.checkInDate || existingBooking.checkInDate;
-      const effectiveCheckOut =
-        updateData.checkOutDate || existingBooking.checkOutDate;
-      updateData.numNights = differenceInCalendarDays(
-        new Date(effectiveCheckOut),
-        new Date(effectiveCheckIn)
-      );
-    }
+    // numNights/cabinPrice/extrasPrice/totalPrice are already recomputed above
+    // (in the shouldValidateBookingRules block) whenever dates, cabin,
+    // numGuests, or extras change — findByIdAndUpdate bypasses the Mongoose
+    // pre-save hook that would otherwise handle this.
 
     if (
       updateData.totalPrice !== undefined ||
@@ -689,6 +702,17 @@ export async function PUT(request: NextRequest) {
       ...(_clerkWarning ? { _clerkWarning } : {}),
     });
   } catch (error: unknown) {
+    // A same-calendar-day date change can pass the Zod refine (which only
+    // compares raw timestamps) but yield zero nights once
+    // calculateBookingPricing measures calendar days — surface that as a
+    // 400, not a generic server error.
+    if (error instanceof BookingPricingError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 400 }
+      );
+    }
+
     if (isMongooseValidationError(error)) {
       logger.warn(
         'Mongoose validation fired after Zod passed — possible schema drift (PUT)',

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -425,6 +425,7 @@ export async function PUT(request: NextRequest) {
     // boundary as POST (see calculateBookingPricing in lib/booking-pricing.ts
     // and issue #122). These are only ever set below, recomputed from the
     // cabin/settings documents when a pricing-relevant field actually changes.
+    delete updateData.numNights;
     delete updateData.cabinPrice;
     delete updateData.extrasPrice;
     delete updateData.totalPrice;

--- a/lib/booking-pricing.ts
+++ b/lib/booking-pricing.ts
@@ -83,12 +83,15 @@ export function calculateBookingPricing({
   extras,
 }: BookingPricingInput): BookingPricingResult {
   const numNights = differenceInCalendarDays(checkOutDate, checkInDate);
-  if (numNights < 1) {
+  // NaN comparisons are always false, so an invalid date/guest count must be
+  // rejected explicitly — otherwise it silently passes the `< 1` guard below
+  // and propagates as a NaN price instead of a 400.
+  if (!Number.isFinite(numNights) || numNights < 1) {
     throw new BookingPricingError(
       'checkOutDate must be at least one day after checkInDate'
     );
   }
-  if (numGuests < 1) {
+  if (!Number.isFinite(numGuests) || numGuests < 1) {
     throw new BookingPricingError('numGuests must be at least 1');
   }
 

--- a/lib/validations/booking.ts
+++ b/lib/validations/booking.ts
@@ -86,6 +86,12 @@ export const updateBookingSchema = z
     numGuests: z.number().int().min(1).max(50).optional(),
     numNights: z.number().int().min(1).optional(),
     status: bookingStatusSchema.optional(),
+    // numNights, cabinPrice, extrasPrice, and totalPrice are accepted here for
+    // schema shape only — the API route recomputes them server-side from the
+    // cabin and settings documents whenever a pricing-relevant field (cabin,
+    // dates, numGuests, extras) changes, and otherwise ignores any
+    // client-supplied value outright (see calculateBookingPricing in
+    // lib/booking-pricing.ts and issue #122).
     cabinPrice: z.number().min(0).optional(),
     extrasPrice: z.number().min(0).optional(),
     totalPrice: z.number().min(0).optional(),

--- a/lib/validations/booking.ts
+++ b/lib/validations/booking.ts
@@ -84,14 +84,14 @@ export const updateBookingSchema = z
     checkInDate: z.coerce.date().optional(),
     checkOutDate: z.coerce.date().optional(),
     numGuests: z.number().int().min(1).max(50).optional(),
-    numNights: z.number().int().min(1).optional(),
-    status: bookingStatusSchema.optional(),
     // numNights, cabinPrice, extrasPrice, and totalPrice are accepted here for
     // schema shape only — the API route recomputes them server-side from the
     // cabin and settings documents whenever a pricing-relevant field (cabin,
     // dates, numGuests, extras) changes, and otherwise ignores any
     // client-supplied value outright (see calculateBookingPricing in
     // lib/booking-pricing.ts and issue #122).
+    numNights: z.number().int().min(1).optional(),
+    status: bookingStatusSchema.optional(),
     cabinPrice: z.number().min(0).optional(),
     extrasPrice: z.number().min(0).optional(),
     totalPrice: z.number().min(0).optional(),

--- a/lib/validations/booking.ts
+++ b/lib/validations/booking.ts
@@ -84,12 +84,14 @@ export const updateBookingSchema = z
     checkInDate: z.coerce.date().optional(),
     checkOutDate: z.coerce.date().optional(),
     numGuests: z.number().int().min(1).max(50).optional(),
-    // numNights, cabinPrice, extrasPrice, and totalPrice are accepted here for
-    // schema shape only — the API route recomputes them server-side from the
-    // cabin and settings documents whenever a pricing-relevant field (cabin,
-    // dates, numGuests, extras) changes, and otherwise ignores any
-    // client-supplied value outright (see calculateBookingPricing in
-    // lib/booking-pricing.ts and issue #122).
+    // numNights, cabinPrice, extrasPrice, totalPrice, and remainingAmount
+    // (below) are accepted here for schema shape only — the API route
+    // recomputes numNights/cabinPrice/extrasPrice/totalPrice server-side from
+    // the cabin and settings documents whenever a pricing-relevant field
+    // (cabin, dates, numGuests, extras) changes, and remainingAmount from
+    // totalPrice/depositAmount whenever either changes. Client-supplied
+    // values for all of these are ignored outright (see
+    // calculateBookingPricing in lib/booking-pricing.ts and issue #122).
     numNights: z.number().int().min(1).optional(),
     status: bookingStatusSchema.optional(),
     cabinPrice: z.number().min(0).optional(),


### PR DESCRIPTION
Closes #122.

## Summary
- Strips client-supplied `cabinPrice`/`extrasPrice`/`totalPrice`/`numNights`/`remainingAmount` from `PUT /api/bookings` update payloads unconditionally, matching the `POST` trust boundary established in #121 — all five are fully server-derived fields that `findByIdAndUpdate` would otherwise write verbatim, bypassing the Mongoose pre-save hook that normally recomputes them
- Recomputes `numNights`/`cabinPrice`/`extrasPrice`/`totalPrice`/`extras` (including `extras.*Fee`) via `calculateBookingPricing()` (`lib/booking-pricing.ts`) whenever a pricing-relevant field (`cabin`, `checkInDate`, `checkOutDate`, `numGuests`, `extras`) actually changes on update; `remainingAmount` is re-derived from `totalPrice`/`depositAmount` whenever either changes, as before
- Adds `BookingPricingError` handling to `PUT`'s catch block (400, not 500), mirroring `POST`
- Guards `calculateBookingPricing()` against `NaN` `numNights`/`numGuests` (e.g. an invalid date) with explicit `Number.isFinite()` checks — `NaN` comparisons are always `false`, so `numNights < 1` alone silently let an invalid input through as a `NaN` price instead of throwing
- Removes the now-redundant manual `numNights` recompute (superseded by `calculateBookingPricing`'s `differenceInCalendarDays` calculation, which also resolves the prior `Math.ceil` vs `differenceInCalendarDays` inconsistency between the min/max-nights validation and the persisted value)
- Documents in `updateBookingSchema` (`lib/validations/booking.ts`) that these fields are accepted for schema shape only and always ignored/recomputed server-side, matching the existing comment on `createBookingSchema`
- Updates `__tests__/integration/api/bookings.test.ts` and `__tests__/unit/lib/booking-pricing.test.ts`: replaces the now-conflicting `recalculates remainingAmount when totalPrice changes` test (which asserted a client could set `totalPrice` directly) with coverage for direct price/numNights/remainingAmount tampering being ignored, tampered `extras.*Fee` values, cabin-change and numGuests-change recompute, a deposit-only update, the new `BookingPricingError` 400 path, and the `NaN`-guard

## Why
Issue #122's acceptance criteria included a decision on whether `PUT` should allow direct `totalPrice`/`cabinPrice`/`extrasPrice` edits. Per direction, the decision is: no — lock `PUT` down the same way `POST` already is, removing the "manual admin price override" the previous test encoded. Review (three rounds of `/pr-review-toolkit:review-pr`) surfaced that `numNights` and `remainingAmount` are the same class of client-writable-but-server-derived field and needed the identical treatment.

## Out of scope
- The issue also flags `depositAmount` as accepted from client input on `POST`/`PUT` without validation against `settings.requireDeposit`/`depositPercentage`. Investigated: the admin UI (`hooks/useBookingForm.ts`) already computes `depositAmount` client-side from those same settings before sending it, so it's never legitimately free-form input — but the trusted server-side path for recording real payments is `PATCH /api/bookings/[id]` (`recordPayment`), which derives balances itself rather than trusting an opaque `depositAmount`. Recomputing `depositAmount` server-side on every `PUT` would risk silently overwriting a previously-recorded real payment when an unrelated field (e.g. guest count) is edited later. This needs its own decision and is left as a follow-up rather than bundled into this fix.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 897 passing (51 suites)
- [x] `pnpm lint` — no errors
- [x] `pnpm format:check` — clean
- [x] Reviewed with `/pr-review-toolkit:review-pr` for 3 rounds (code-reviewer, pr-test-analyzer, silent-failure-hunter); all critical/important findings across all rounds patched (test coverage gaps, a `NaN`-guard, and two additional un-stripped server-derived fields — `numNights` and `remainingAmount`)