### PR TITLE
Fix booking overlap TOCTOU race with a per-cabin write lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ const data = validationResult.data;
 - `Experience` — Activities/tours with difficulty, duration, participants
 - `Settings` — Business rules, pricing policies (singleton — DO NOT modify directly)
 - `ProcessedStripeEvent` — Idempotency store for Stripe webhook events (TTL index, 30-day expiry)
+- `CabinBookingLock` — Per-cabin mutex for booking create/update requests, preventing overlap-check TOCTOU races (unique index on `cabin`)
 
 **Important Indexes:**
 - Bookings: Compound indexes on `{ cabin, checkInDate, checkOutDate }`, `{ customer, createdAt }`
@@ -367,6 +368,29 @@ const overlapping = await Booking.findOverlapping(
 if (overlapping.length > 0) {
   // Handle conflict
 }
+```
+
+**`findOverlapping()` alone is not concurrency-safe** — it's a plain read
+with no lock, so two simultaneous requests can both pass the check before
+either write lands. `POST /api/bookings` and `PUT /api/bookings` (in
+`app/api/bookings/route.ts`) guard against this by wrapping the
+check-then-write critical section in `withCabinBookingLock()`
+(`lib/cabin-booking-lock.ts`), an application-level per-cabin mutex backed
+by an atomic upsert against a unique index on `CabinBookingLock.cabin` —
+not a MongoDB transaction, since two transactions inserting *different*
+documents don't produce a write conflict under Mongo's transaction
+semantics. Any new code path that creates or reschedules a booking must
+go through the same lock:
+
+```typescript
+import { withCabinBookingLock } from '@/lib/cabin-booking-lock';
+
+const result = await withCabinBookingLock(cabinId, async () => {
+  const overlapping = await Booking.findOverlapping(cabinId, checkInDate, checkOutDate);
+  if (overlapping.length > 0) return { ok: false as const };
+  const booking = await Booking.create({ ... });
+  return { ok: true as const, booking };
+});
 ```
 
 Settings is the single source of truth for booking business rules (min/max nights, deposit %, etc.). Booking API validation reads from the Settings document at request time.

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server';
 jest.mock('@/lib/mongodb', () => jest.fn().mockResolvedValue(undefined));
 
 import { GET, POST, PUT, DELETE } from '@/app/api/bookings/route';
+import * as cabinBookingLock from '@/lib/cabin-booking-lock';
 import Booking from '@/models/Booking';
 import Cabin from '@/models/Cabin';
 import Settings from '@/models/Settings';
@@ -478,6 +479,37 @@ describe('Bookings API Routes', () => {
       const allBookings = await Booking.find({ cabin: cabin._id });
       expect(allBookings).toHaveLength(1);
     });
+
+    it('returns 409 (not 500) when the cabin booking lock times out', async () => {
+      const cabin = await createTestCabin();
+      const lockSpy = jest
+        .spyOn(cabinBookingLock, 'withCabinBookingLock')
+        .mockRejectedValueOnce(
+          new cabinBookingLock.CabinBookingLockTimeoutError(
+            cabin._id.toString()
+          )
+        );
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-09-01',
+          checkOutDate: '2027-09-05',
+          numGuests: 2,
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('try again');
+
+      lockSpy.mockRestore();
+    });
   });
 
   describe('PUT /api/bookings', () => {
@@ -908,6 +940,36 @@ describe('Bookings API Routes', () => {
         checkInDate: new Date('2027-12-01'),
       });
       expect(decemberBookings).toHaveLength(1);
+    });
+
+    it('returns 409 (not 500) when the cabin booking lock times out on a date change', async () => {
+      const cabin = await createTestCabin();
+      const booking = await createTestBooking(cabin._id);
+      const lockSpy = jest
+        .spyOn(cabinBookingLock, 'withCabinBookingLock')
+        .mockRejectedValueOnce(
+          new cabinBookingLock.CabinBookingLockTimeoutError(
+            cabin._id.toString()
+          )
+        );
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'PUT',
+        body: {
+          _id: booking._id.toString(),
+          checkInDate: '2027-12-01',
+          checkOutDate: '2027-12-05',
+        },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('try again');
+
+      lockSpy.mockRestore();
     });
   });
 

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -441,6 +441,43 @@ describe('Bookings API Routes', () => {
       expect(body.success).toBe(false);
       expect(body.error).toContain('checkOutDate');
     });
+
+    it('under concurrent overlapping requests for the same cabin, exactly one succeeds and the other gets 409', async () => {
+      const cabin = await createTestCabin();
+
+      const buildRequest = () =>
+        createRequest('http://localhost:3000/api/bookings', {
+          method: 'POST',
+          body: {
+            cabin: cabin._id.toString(),
+            customer: 'user_test123',
+            checkInDate: '2027-09-01',
+            checkOutDate: '2027-09-05',
+            numGuests: 2,
+          },
+        });
+
+      const [responseA, responseB] = await Promise.all([
+        POST(buildRequest()),
+        POST(buildRequest()),
+      ]);
+      const [bodyA, bodyB] = await Promise.all([
+        responseA.json(),
+        responseB.json(),
+      ]);
+
+      const statuses = [responseA.status, responseB.status].sort();
+      expect(statuses).toEqual([201, 409]);
+
+      const succeeded = responseA.status === 201 ? bodyA : bodyB;
+      const failed = responseA.status === 409 ? bodyA : bodyB;
+      expect(succeeded.success).toBe(true);
+      expect(failed.success).toBe(false);
+      expect(failed.error).toContain('overlap');
+
+      const allBookings = await Booking.find({ cabin: cabin._id });
+      expect(allBookings).toHaveLength(1);
+    });
   });
 
   describe('PUT /api/bookings', () => {

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -861,6 +861,54 @@ describe('Bookings API Routes', () => {
       expect(body.success).toBe(false);
       expect(body.error).toContain('checkOutDate');
     });
+
+    it('under concurrent updates that both move bookings into an overlapping range, exactly one succeeds and the other gets 409', async () => {
+      const cabin = await createTestCabin();
+      // Two existing bookings, far apart — no overlap yet.
+      const bookingA = await createTestBooking(cabin._id, {
+        checkInDate: new Date('2027-10-01'),
+        checkOutDate: new Date('2027-10-04'),
+      });
+      const bookingB = await createTestBooking(cabin._id, {
+        checkInDate: new Date('2027-11-01'),
+        checkOutDate: new Date('2027-11-04'),
+      });
+
+      // Both concurrently move into the same overlapping window.
+      const buildRequest = (id: string) =>
+        createRequest('http://localhost:3000/api/bookings', {
+          method: 'PUT',
+          body: {
+            _id: id,
+            checkInDate: '2027-12-01',
+            checkOutDate: '2027-12-05',
+          },
+        });
+
+      const [responseA, responseB] = await Promise.all([
+        PUT(buildRequest(bookingA._id.toString())),
+        PUT(buildRequest(bookingB._id.toString())),
+      ]);
+      const [bodyA, bodyB] = await Promise.all([
+        responseA.json(),
+        responseB.json(),
+      ]);
+
+      const statuses = [responseA.status, responseB.status].sort();
+      expect(statuses).toEqual([200, 409]);
+
+      const succeeded = responseA.status === 200 ? bodyA : bodyB;
+      const failed = responseA.status === 409 ? bodyA : bodyB;
+      expect(succeeded.success).toBe(true);
+      expect(failed.success).toBe(false);
+      expect(failed.error).toContain('overlap');
+
+      const decemberBookings = await Booking.find({
+        cabin: cabin._id,
+        checkInDate: new Date('2027-12-01'),
+      });
+      expect(decemberBookings).toHaveLength(1);
+    });
   });
 
   describe('DELETE /api/bookings', () => {

--- a/__tests__/integration/lib/cabin-booking-lock.test.ts
+++ b/__tests__/integration/lib/cabin-booking-lock.test.ts
@@ -1,6 +1,9 @@
 import mongoose from 'mongoose';
 
-import { withCabinBookingLock } from '@/lib/cabin-booking-lock';
+import {
+  CabinBookingLockTimeoutError,
+  withCabinBookingLock,
+} from '@/lib/cabin-booking-lock';
 import CabinBookingLock from '@/models/CabinBookingLock';
 
 describe('withCabinBookingLock', () => {
@@ -65,5 +68,89 @@ describe('withCabinBookingLock', () => {
     expect(result).toBe('reclaimed');
     // Should acquire on the first attempt, not after retrying for seconds.
     expect(elapsedMs).toBeLessThan(500);
+  });
+
+  it('does not serialize callbacks for different cabins', async () => {
+    const cabinA = new mongoose.Types.ObjectId();
+    const cabinB = new mongoose.Types.ObjectId();
+    const order: string[] = [];
+
+    const lockA = withCabinBookingLock(cabinA, async () => {
+      order.push('a-start');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      order.push('a-end');
+    });
+
+    // Give A a chance to acquire its (unrelated) lock first.
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    const lockB = withCabinBookingLock(cabinB, async () => {
+      order.push('b-start');
+      order.push('b-end');
+    });
+
+    await Promise.all([lockA, lockB]);
+
+    // B must not have to wait for A's unrelated lock to release.
+    expect(order.indexOf('b-start')).toBeLessThan(order.indexOf('a-end'));
+  });
+
+  it('lets only one of two concurrent reclaimers win the same stale lock', async () => {
+    await CabinBookingLock.create({
+      cabin: cabinId,
+      token: 'stale-token',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const order: string[] = [];
+    const runs = ['first', 'second'].map(label =>
+      withCabinBookingLock(cabinId, async () => {
+        order.push(`${label}-start`);
+        await new Promise(resolve => setTimeout(resolve, 50));
+        order.push(`${label}-end`);
+      })
+    );
+
+    await Promise.all(runs);
+
+    // Whichever reclaims first must fully finish before the other starts
+    // — never interleaved, even though both raced the same expired doc.
+    expect(order).toEqual(
+      order[0] === 'first-start'
+        ? ['first-start', 'first-end', 'second-start', 'second-end']
+        : ['second-start', 'second-end', 'first-start', 'first-end']
+    );
+  });
+
+  it('does not mask a successful result when releasing the lock fails', async () => {
+    const releaseSpy = jest
+      .spyOn(CabinBookingLock, 'deleteOne')
+      .mockRejectedValueOnce(new Error('transient release failure'));
+
+    const result = await withCabinBookingLock(cabinId, async () => 'done');
+
+    expect(result).toBe('done');
+    releaseSpy.mockRestore();
+  });
+
+  it('does not mask the original error when releasing the lock also fails', async () => {
+    const releaseSpy = jest
+      .spyOn(CabinBookingLock, 'deleteOne')
+      .mockRejectedValueOnce(new Error('transient release failure'));
+
+    await expect(
+      withCabinBookingLock(cabinId, async () => {
+        throw new Error('original failure');
+      })
+    ).rejects.toThrow('original failure');
+
+    releaseSpy.mockRestore();
+  });
+
+  it('CabinBookingLockTimeoutError carries the cabin id in its message', () => {
+    const error = new CabinBookingLockTimeoutError(cabinId.toString());
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('CabinBookingLockTimeoutError');
+    expect(error.message).toContain(cabinId.toString());
   });
 });

--- a/__tests__/integration/lib/cabin-booking-lock.test.ts
+++ b/__tests__/integration/lib/cabin-booking-lock.test.ts
@@ -1,0 +1,69 @@
+import mongoose from 'mongoose';
+
+import { withCabinBookingLock } from '@/lib/cabin-booking-lock';
+import CabinBookingLock from '@/models/CabinBookingLock';
+
+describe('withCabinBookingLock', () => {
+  const cabinId = new mongoose.Types.ObjectId();
+
+  it('runs the callback and returns its result', async () => {
+    const result = await withCabinBookingLock(cabinId, async () => 'done');
+    expect(result).toBe('done');
+  });
+
+  it('releases the lock after the callback resolves', async () => {
+    await withCabinBookingLock(cabinId, async () => 'done');
+    const remaining = await CabinBookingLock.findOne({ cabin: cabinId });
+    expect(remaining).toBeNull();
+  });
+
+  it('releases the lock after the callback throws', async () => {
+    await expect(
+      withCabinBookingLock(cabinId, async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+
+    const remaining = await CabinBookingLock.findOne({ cabin: cabinId });
+    expect(remaining).toBeNull();
+  });
+
+  it('serializes two concurrent callbacks for the same cabin', async () => {
+    const order: string[] = [];
+
+    const first = withCabinBookingLock(cabinId, async () => {
+      order.push('first-start');
+      await new Promise(resolve => setTimeout(resolve, 50));
+      order.push('first-end');
+    });
+
+    // Give `first` a chance to acquire the lock before `second` tries.
+    await new Promise(resolve => setTimeout(resolve, 5));
+
+    const second = withCabinBookingLock(cabinId, async () => {
+      order.push('second-start');
+    });
+
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(['first-start', 'first-end', 'second-start']);
+  });
+
+  it('reclaims a stale (expired) lock instead of waiting out the full TTL', async () => {
+    // Simulate a crashed holder: a lock doc whose expiresAt is already
+    // in the past.
+    await CabinBookingLock.create({
+      cabin: cabinId,
+      token: 'stale-token',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const start = Date.now();
+    const result = await withCabinBookingLock(cabinId, async () => 'reclaimed');
+    const elapsedMs = Date.now() - start;
+
+    expect(result).toBe('reclaimed');
+    // Should acquire on the first attempt, not after retrying for seconds.
+    expect(elapsedMs).toBeLessThan(500);
+  });
+});

--- a/__tests__/integration/lib/cabin-booking-lock.test.ts
+++ b/__tests__/integration/lib/cabin-booking-lock.test.ts
@@ -153,4 +153,26 @@ describe('withCabinBookingLock', () => {
     expect(error.name).toBe('CabinBookingLockTimeoutError');
     expect(error.message).toContain(cabinId.toString());
   });
+
+  it('gives up and throws CabinBookingLockTimeoutError once the acquire budget is exhausted', async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+    const permanentCollision = Object.assign(
+      new Error('E11000 duplicate key error'),
+      { code: 11000 }
+    );
+    const acquireSpy = jest
+      .spyOn(CabinBookingLock, 'findOneAndUpdate')
+      .mockRejectedValue(permanentCollision);
+
+    const assertion = expect(
+      withCabinBookingLock(cabinId, async () => 'unreachable')
+    ).rejects.toThrow(CabinBookingLockTimeoutError);
+
+    // Fast-forward through every retry sleep instead of waiting ~13s.
+    await jest.advanceTimersByTimeAsync(20_000);
+    await assertion;
+
+    acquireSpy.mockRestore();
+    jest.useRealTimers();
+  });
 });

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -650,30 +650,8 @@ export async function PUT(request: NextRequest) {
       updateData.checkOutDate &&
       new Date(updateData.checkOutDate).getTime() !==
         existingBooking.checkOutDate.getTime();
-
-    if (cabinChanged || checkInChanged || checkOutChanged) {
-      const cabinId = updateData.cabin || existingBooking.cabin;
-      const checkIn = updateData.checkInDate || existingBooking.checkInDate;
-      const checkOut = updateData.checkOutDate || existingBooking.checkOutDate;
-
-      const overlapping = await Booking.findOverlapping(
-        cabinId,
-        checkIn,
-        checkOut,
-        new mongoose.Types.ObjectId(_id)
-      );
-
-      if (overlapping.length > 0) {
-        return NextResponse.json(
-          {
-            success: false,
-            error:
-              'The selected dates overlap with an existing booking for this cabin',
-          },
-          { status: 409 }
-        );
-      }
-    }
+    const shouldCheckOverlap =
+      cabinChanged || checkInChanged || checkOutChanged;
 
     // numNights/cabinPrice/extrasPrice/totalPrice are already recomputed above
     // (in the shouldValidateBookingRules block) whenever dates, cabin,
@@ -694,9 +672,49 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const booking = await Booking.findByIdAndUpdate(_id, updateData, {
-      new: true,
-    }).populate('cabin', 'name image capacity price discount');
+    // When dates/cabin change, the overlap check and the write that acts
+    // on it are wrapped in the same per-cabin lock used by POST (see
+    // issue #110) so two concurrent updates can't both pass the check
+    // before either write lands.
+    let booking;
+    if (shouldCheckOverlap) {
+      const cabinId = updateData.cabin || existingBooking.cabin;
+      const checkIn = updateData.checkInDate || existingBooking.checkInDate;
+      const checkOut = updateData.checkOutDate || existingBooking.checkOutDate;
+
+      const lockResult = await withCabinBookingLock(cabinId, async () => {
+        const overlapping = await Booking.findOverlapping(
+          cabinId,
+          checkIn,
+          checkOut,
+          new mongoose.Types.ObjectId(_id)
+        );
+        if (overlapping.length > 0) {
+          return { ok: false as const };
+        }
+
+        const updated = await Booking.findByIdAndUpdate(_id, updateData, {
+          new: true,
+        }).populate('cabin', 'name image capacity price discount');
+        return { ok: true as const, booking: updated };
+      });
+
+      if (!lockResult.ok) {
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              'The selected dates overlap with an existing booking for this cabin',
+          },
+          { status: 409 }
+        );
+      }
+      booking = lockResult.booking;
+    } else {
+      booking = await Booking.findByIdAndUpdate(_id, updateData, {
+        new: true,
+      }).populate('cabin', 'name image capacity price discount');
+    }
 
     if (!booking) {
       return NextResponse.json(

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -9,7 +9,11 @@ import {
   BookingPricingError,
   calculateBookingPricing,
 } from '@/lib/booking-pricing';
-import { withCabinBookingLock } from '@/lib/cabin-booking-lock';
+import {
+  CabinBookingLockTimeoutError,
+  withCabinBookingLock,
+  type LockedWriteResult,
+} from '@/lib/cabin-booking-lock';
 import { getClerkUsersBatch, searchClerkUsers } from '@/lib/clerk-users';
 import { VALID_TRANSITIONS } from '@/lib/config';
 import { logger } from '@/lib/logger';
@@ -303,7 +307,7 @@ export async function POST(request: NextRequest) {
     // in a per-cabin lock so two concurrent requests can't both pass the
     // check before either write lands (see issue #110 — findOverlapping is
     // a plain read with no lock, so check-then-write alone is not atomic).
-    const lockResult = await withCabinBookingLock(
+    const lockResult = await withCabinBookingLock<LockedWriteResult<IBooking>>(
       validationResult.data.cabin,
       async () => {
         const overlapping = await Booking.findOverlapping(
@@ -312,7 +316,7 @@ export async function POST(request: NextRequest) {
           checkOutDate
         );
         if (overlapping.length > 0) {
-          return { ok: false as const };
+          return { ok: false };
         }
 
         const created = await Booking.create({
@@ -323,7 +327,7 @@ export async function POST(request: NextRequest) {
           totalPrice: pricing.totalPrice,
           extras: pricing.extras,
         });
-        return { ok: true as const, booking: created };
+        return { ok: true, booking: created };
       }
     );
 
@@ -375,6 +379,23 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { success: false, error: error.message },
         { status: 400 }
+      );
+    }
+
+    // The cabin's booking lock stayed contended past the acquire budget —
+    // heavy concurrent activity on this cabin, not a server fault. Surface
+    // as a retryable 409 rather than a generic 500.
+    if (error instanceof CabinBookingLockTimeoutError) {
+      logger.warn('Booking lock contention timed out (POST)', {
+        message: error.message,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'This cabin is receiving a lot of booking activity right now — please try again in a moment.',
+        },
+        { status: 409 }
       );
     }
 
@@ -682,7 +703,9 @@ export async function PUT(request: NextRequest) {
       const checkIn = updateData.checkInDate || existingBooking.checkInDate;
       const checkOut = updateData.checkOutDate || existingBooking.checkOutDate;
 
-      const lockResult = await withCabinBookingLock(cabinId, async () => {
+      const lockResult = await withCabinBookingLock<
+        LockedWriteResult<IBooking | null>
+      >(cabinId, async () => {
         const overlapping = await Booking.findOverlapping(
           cabinId,
           checkIn,
@@ -690,13 +713,13 @@ export async function PUT(request: NextRequest) {
           new mongoose.Types.ObjectId(_id)
         );
         if (overlapping.length > 0) {
-          return { ok: false as const };
+          return { ok: false };
         }
 
         const updated = await Booking.findByIdAndUpdate(_id, updateData, {
           new: true,
         }).populate('cabin', 'name image capacity price discount');
-        return { ok: true as const, booking: updated };
+        return { ok: true, booking: updated };
       });
 
       if (!lockResult.ok) {
@@ -746,6 +769,23 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json(
         { success: false, error: error.message },
         { status: 400 }
+      );
+    }
+
+    // The cabin's booking lock stayed contended past the acquire budget —
+    // heavy concurrent activity on this cabin, not a server fault. Surface
+    // as a retryable 409 rather than a generic 500.
+    if (error instanceof CabinBookingLockTimeoutError) {
+      logger.warn('Booking lock contention timed out (PUT)', {
+        message: error.message,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'This cabin is receiving a lot of booking activity right now — please try again in a moment.',
+        },
+        { status: 409 }
       );
     }
 

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -9,6 +9,7 @@ import {
   BookingPricingError,
   calculateBookingPricing,
 } from '@/lib/booking-pricing';
+import { withCabinBookingLock } from '@/lib/cabin-booking-lock';
 import { getClerkUsersBatch, searchClerkUsers } from '@/lib/clerk-users';
 import { VALID_TRANSITIONS } from '@/lib/config';
 import { logger } from '@/lib/logger';
@@ -297,14 +298,36 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Prevent double-bookings: reject if the cabin is already booked
-    // for an overlapping date range
-    const overlapping = await Booking.findOverlapping(
+    // Prevent double-bookings: reject if the cabin is already booked for an
+    // overlapping date range. The overlap check and the create are wrapped
+    // in a per-cabin lock so two concurrent requests can't both pass the
+    // check before either write lands (see issue #110 — findOverlapping is
+    // a plain read with no lock, so check-then-write alone is not atomic).
+    const lockResult = await withCabinBookingLock(
       validationResult.data.cabin,
-      checkInDate,
-      checkOutDate
+      async () => {
+        const overlapping = await Booking.findOverlapping(
+          validationResult.data.cabin,
+          checkInDate,
+          checkOutDate
+        );
+        if (overlapping.length > 0) {
+          return { ok: false as const };
+        }
+
+        const created = await Booking.create({
+          ...validationResult.data,
+          numNights: pricing.numNights,
+          cabinPrice: pricing.cabinPrice,
+          extrasPrice: pricing.extrasPrice,
+          totalPrice: pricing.totalPrice,
+          extras: pricing.extras,
+        });
+        return { ok: true as const, booking: created };
+      }
     );
-    if (overlapping.length > 0) {
+
+    if (!lockResult.ok) {
       return NextResponse.json(
         {
           success: false,
@@ -315,14 +338,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const booking = await Booking.create({
-      ...validationResult.data,
-      numNights: pricing.numNights,
-      cabinPrice: pricing.cabinPrice,
-      extrasPrice: pricing.extrasPrice,
-      totalPrice: pricing.totalPrice,
-      extras: pricing.extras,
-    });
+    const booking = lockResult.booking;
 
     // Populate the response
     const populatedBooking = await Booking.findById(booking._id).populate(

--- a/lib/cabin-booking-lock.ts
+++ b/lib/cabin-booking-lock.ts
@@ -1,0 +1,79 @@
+import crypto from 'crypto';
+import mongoose from 'mongoose';
+
+import CabinBookingLock from '@/models/CabinBookingLock';
+
+// How long a lock is held before it's considered stale and can be
+// reclaimed by another request (e.g. the holder crashed mid-request).
+const LOCK_TTL_MS = 10_000;
+// How long to wait, in total, for a currently-held lock to free up
+// before giving up. Legitimate contention (two real concurrent booking
+// requests) resolves in well under a second; this budget only matters
+// when something is stuck.
+const ACQUIRE_RETRY_DELAY_MS = 50;
+const ACQUIRE_MAX_ATTEMPTS = 60; // ~3s worst case
+
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: number }).code === 11000
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Serializes booking create/update requests for a single cabin so the
+ * "check for overlap, then write" critical section in
+ * `app/api/bookings/route.ts` can't race across concurrent requests
+ * (see issue #110). Backed by an atomic upsert against a unique index on
+ * `CabinBookingLock.cabin`, not a MongoDB transaction — two transactions
+ * each inserting a *different* document don't conflict under MongoDB's
+ * transaction semantics, so a transaction alone wouldn't close this race.
+ */
+export async function withCabinBookingLock<T>(
+  cabinId: mongoose.Types.ObjectId | string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const cabinObjectId = new mongoose.Types.ObjectId(cabinId.toString());
+  const token = crypto.randomUUID();
+  let acquired = false;
+
+  for (let attempt = 0; attempt < ACQUIRE_MAX_ATTEMPTS; attempt++) {
+    const now = new Date();
+    try {
+      // Matches only when no lock exists yet for this cabin, or the
+      // existing lock has expired — otherwise this update matches
+      // nothing and Mongo attempts an upsert insert, which collides
+      // with the unique index on `cabin` and throws E11000.
+      await CabinBookingLock.findOneAndUpdate(
+        { cabin: cabinObjectId, expiresAt: { $lt: now } },
+        { $set: { token, expiresAt: new Date(now.getTime() + LOCK_TTL_MS) } },
+        { upsert: true }
+      );
+      acquired = true;
+      break;
+    } catch (error) {
+      if (!isDuplicateKeyError(error)) throw error;
+      await sleep(ACQUIRE_RETRY_DELAY_MS);
+    }
+  }
+
+  if (!acquired) {
+    throw new Error(
+      `Timed out waiting for booking lock on cabin ${cabinObjectId.toString()}`
+    );
+  }
+
+  try {
+    return await fn();
+  } finally {
+    // Only release the lock if we still hold it (matches by token) —
+    // if our TTL expired and someone else stole it, don't delete theirs.
+    await CabinBookingLock.deleteOne({ cabin: cabinObjectId, token });
+  }
+}

--- a/lib/cabin-booking-lock.ts
+++ b/lib/cabin-booking-lock.ts
@@ -1,17 +1,36 @@
 import crypto from 'crypto';
 import mongoose from 'mongoose';
 
+import { logger } from '@/lib/logger';
 import CabinBookingLock from '@/models/CabinBookingLock';
 
 // How long a lock is held before it's considered stale and can be
 // reclaimed by another request (e.g. the holder crashed mid-request).
 const LOCK_TTL_MS = 10_000;
-// How long to wait, in total, for a currently-held lock to free up
-// before giving up. Legitimate contention (two real concurrent booking
-// requests) resolves in well under a second; this budget only matters
-// when something is stuck.
+// How long to wait, in total, for a currently-held lock to free up before
+// giving up. Kept comfortably above LOCK_TTL_MS: a legitimate holder can
+// validly hold the lock for the full TTL, and a waiter that gives up
+// sooner than that would spuriously fail a request that was never stuck —
+// just queued behind a slow-but-valid critical section.
 const ACQUIRE_RETRY_DELAY_MS = 50;
-const ACQUIRE_MAX_ATTEMPTS = 60; // ~3s worst case
+const ACQUIRE_MAX_ATTEMPTS = 260; // 13s nominal, above the 10s TTL
+
+/**
+ * Thrown when a cabin's lock stays held (by a live or crashed holder)
+ * longer than the acquire budget. Callers should treat this as "the
+ * cabin is under heavy write contention right now" (a 409/retry signal),
+ * not a generic server error.
+ */
+export class CabinBookingLockTimeoutError extends Error {
+  constructor(cabinId: string) {
+    super(`Timed out waiting for booking lock on cabin ${cabinId}`);
+    this.name = 'CabinBookingLockTimeoutError';
+    Object.setPrototypeOf(this, CabinBookingLockTimeoutError.prototype);
+  }
+}
+
+/** Discriminated result of a locked write that may be rejected by an overlap check. */
+export type LockedWriteResult<T> = { ok: true; booking: T } | { ok: false };
 
 function isDuplicateKeyError(error: unknown): boolean {
   return (
@@ -46,14 +65,16 @@ export async function withCabinBookingLock<T>(
   for (let attempt = 0; attempt < ACQUIRE_MAX_ATTEMPTS; attempt++) {
     const now = new Date();
     try {
-      // Matches only when no lock exists yet for this cabin, or the
-      // existing lock has expired — otherwise this update matches
-      // nothing and Mongo attempts an upsert insert, which collides
-      // with the unique index on `cabin` and throws E11000.
+      // If no lock exists yet for this cabin, or the existing one has
+      // expired, this filter matches and the upsert succeeds (as an
+      // insert or an in-place update, respectively). If an active,
+      // non-expired lock already exists, the filter matches nothing, so
+      // Mongo attempts an upsert *insert* instead — which collides with
+      // the unique index on `cabin` and throws E11000.
       await CabinBookingLock.findOneAndUpdate(
         { cabin: cabinObjectId, expiresAt: { $lt: now } },
         { $set: { token, expiresAt: new Date(now.getTime() + LOCK_TTL_MS) } },
-        { upsert: true }
+        { upsert: true, runValidators: true }
       );
       acquired = true;
       break;
@@ -64,16 +85,36 @@ export async function withCabinBookingLock<T>(
   }
 
   if (!acquired) {
-    throw new Error(
-      `Timed out waiting for booking lock on cabin ${cabinObjectId.toString()}`
-    );
+    throw new CabinBookingLockTimeoutError(cabinObjectId.toString());
+  }
+
+  // Never let a release failure below mask fn()'s real outcome — a lock
+  // document a release couldn't delete simply self-heals via its TTL, but
+  // silently swapping a successful write (or a specific, meaningful
+  // error) for an unrelated release error is far worse than a stray
+  // lock document.
+  let settled: { ok: true; value: T } | { ok: false; error: unknown };
+  try {
+    settled = { ok: true, value: await fn() };
+  } catch (error) {
+    settled = { ok: false, error };
   }
 
   try {
-    return await fn();
-  } finally {
-    // Only release the lock if we still hold it (matches by token) —
-    // if our TTL expired and someone else stole it, don't delete theirs.
     await CabinBookingLock.deleteOne({ cabin: cabinObjectId, token });
+  } catch (releaseError) {
+    logger.warn(
+      'Failed to release cabin booking lock (will self-heal via TTL)',
+      {
+        cabin: cabinObjectId.toString(),
+        error:
+          releaseError instanceof Error
+            ? releaseError.message
+            : String(releaseError),
+      }
+    );
   }
+
+  if (settled.ok) return settled.value;
+  throw settled.error;
 }

--- a/models/CabinBookingLock.ts
+++ b/models/CabinBookingLock.ts
@@ -28,6 +28,13 @@ const CabinBookingLockSchema: Schema = new Schema(
   }
 );
 
+// Backstop cleanup for orphaned locks (e.g. a cabin that's later deleted
+// while its lock document lingers). The lock's own acquire logic already
+// reclaims expired locks on the next contended request for that cabin;
+// this just guarantees eventual cleanup even if no such request ever
+// comes, mirroring the ProcessedStripeEvent TTL pattern.
+CabinBookingLockSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
 const CabinBookingLock =
   mongoose.models.CabinBookingLock ||
   mongoose.model<ICabinBookingLock>('CabinBookingLock', CabinBookingLockSchema);

--- a/models/CabinBookingLock.ts
+++ b/models/CabinBookingLock.ts
@@ -1,0 +1,38 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface ICabinBookingLock extends Document {
+  cabin: mongoose.Types.ObjectId;
+  token: string;
+  expiresAt: Date;
+}
+
+const CabinBookingLockSchema: Schema = new Schema(
+  {
+    cabin: {
+      type: Schema.Types.ObjectId,
+      ref: 'Cabin',
+      required: true,
+      unique: true,
+    },
+    token: {
+      type: String,
+      required: true,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+  },
+  {
+    timestamps: false,
+  }
+);
+
+const CabinBookingLock =
+  mongoose.models.CabinBookingLock ||
+  mongoose.model<ICabinBookingLock>(
+    'CabinBookingLock',
+    CabinBookingLockSchema
+  );
+
+export default CabinBookingLock;

--- a/models/CabinBookingLock.ts
+++ b/models/CabinBookingLock.ts
@@ -30,9 +30,6 @@ const CabinBookingLockSchema: Schema = new Schema(
 
 const CabinBookingLock =
   mongoose.models.CabinBookingLock ||
-  mongoose.model<ICabinBookingLock>(
-    'CabinBookingLock',
-    CabinBookingLockSchema
-  );
+  mongoose.model<ICabinBookingLock>('CabinBookingLock', CabinBookingLockSchema);
 
 export default CabinBookingLock;

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,5 +1,9 @@
 // Export all models
 export { default as Booking, type IBooking } from './Booking';
+export {
+  default as CabinBookingLock,
+  type ICabinBookingLock,
+} from './CabinBookingLock';
 export { default as Cabin, type ICabin } from './Cabin';
 export { default as Dining, type IDining } from './Dining';
 export { Experience, type IExperience } from './Experience';


### PR DESCRIPTION
Closes #110.

## Summary
- Adds `CabinBookingLock` (`models/CabinBookingLock.ts`), a per-cabin mutex collection with a unique index on `cabin` and a TTL index on `expiresAt` (orphan cleanup backstop, mirrors `ProcessedStripeEvent`)
- Adds `withCabinBookingLock()` (`lib/cabin-booking-lock.ts`) — acquires the lock via an atomic upsert, retries on contention, reclaims stale (expired) locks, and always resolves/rejects with the locked callback's real outcome even if lock release itself fails (logged via `logger.warn`, self-heals via TTL)
- Adds `CabinBookingLockTimeoutError`, thrown when the acquire budget (~13s, kept above the 10s lock TTL) is exhausted; handled explicitly in both `POST`/`PUT /api/bookings` as a retryable `409` instead of a generic `500`
- Wraps the overlap-check-then-write critical section in both `POST /api/bookings` and `PUT /api/bookings` (`app/api/bookings/route.ts`) in `withCabinBookingLock`, so two concurrent requests for the same cabin can no longer both pass `Booking.findOverlapping()` before either write lands
- `PUT` only takes the lock when `cabin`/`checkInDate`/`checkOutDate` actually change — status/refund/pricing-only updates are unaffected
- Extracts the `{ ok, booking }` shape shared by both call sites into an exported `LockedWriteResult<T>` type
- Documents the guard in `CLAUDE.md`'s `### Booking Validation` section and adds `CabinBookingLock` to the Core Collections list

## Why
A MongoDB transaction alone doesn't close this race: two transactions each inserting a *different* new `Booking` document don't produce a write conflict under Mongo's transaction semantics, so both would still commit. An application-level per-cabin mutex is required regardless, so this implements that directly rather than adding transaction machinery the codebase doesn't otherwise use (no `startSession()`/`withTransaction()` exists anywhere in this repo). This also avoids reworking test infra — `mongodb-memory-server` currently starts a standalone instance (`__tests__/setup/globalSetup.ts`), not a replica set, which single-document atomic upserts don't require.

## Test plan
- [x] `pnpm test:integration -- cabin-booking-lock` — 11/11 pass (acquire/release, release-on-throw, per-cabin scoping, concurrent stale-lock reclaim, release-failure doesn't mask outcome, give-up/timeout path)
- [x] `pnpm test:integration -- bookings.test.ts` — 35/35 pass, including concurrent-POST, concurrent-PUT, and lock-timeout-returns-409 tests for both handlers
- [x] `pnpm test` — 912/912 pass (all three Jest projects)
- [x] `pnpm check:types` — clean
- [x] `pnpm format:check` — clean
- [x] Re-ran the two concurrency tests 5x each via full-file runs to check for flakiness — consistently 1×`201`/1×`409` (POST) and 1×`200`/1×`409` (PUT) every run
- [ ] `pnpm lint` — could not get a clean run locally: a separate, git-ignored worktree at `.claude/worktrees/update_claude_md` (another local session's workspace, excluded via `.git/info/exclude`) sits inside this checkout and trips `no-console`/`no-explicit-any` in *its* copy of `scripts/**`, which isn't covered by this repo's `eslint.config.mjs` ignore pattern (`scripts/**` is anchored to the root, not `**/scripts/**`). Confirmed clean by linting only the files this PR touches — 0 problems. This won't appear in CI since that worktree directory isn't tracked by git.

## Notes for reviewer
- This PR went through three rounds of automated multi-agent review (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer). Round 1 found a critical issue (a lock-release failure could mask a successful write as a 500) plus several important gaps (acquire budget shorter than the lock TTL causing spurious timeouts, missing `runValidators`, no TTL index, duplicated return-type shape, and two real test-coverage gaps around per-cabin scoping and concurrent stale-lock reclaim) — all fixed and covered by new tests. Round 2 confirmed those fixes and found two remaining test-coverage gaps (timeout/give-up path, route-level 409 handling) — also closed. Round 3 found no further critical or important issues; all three agents gave an explicit "safe to merge" verdict.
- One deferred, non-blocking suggestion from round 3: `CabinBookingLock` is a bare Mongoose model with no static/instance methods, so the locking protocol (acquire/reclaim/fencing-token release) lives only in `withCabinBookingLock()`, not enforced by the type itself — nothing stops a future script or route from mutating the collection directly and corrupting the mutex. Worth a follow-up issue if the team wants that hardened; out of scope for this fix.