### PR TITLE
Back rate limiting and Clerk user cache with Upstash Redis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,8 @@ lib/                    # Core libraries & configuration
   ├── auth-helpers.ts   # Role-based access helpers
   ├── clerk-users.ts    # Clerk API utilities
   ├── logger.ts         # Structured logging (suppressed in test env)
-  ├── rate-limit.ts     # In-memory rate limiter for mutation/email endpoints
+  ├── redis.ts          # Shared Upstash client for cross-instance state (null when unconfigured)
+  ├── rate-limit.ts     # Rate limiter for mutation/email endpoints (Redis-backed, in-memory fallback)
   ├── booking-pricing.ts # Server-side pricing calculator (see Booking Pricing below)
   ├── validations/      # Zod schemas per domain (booking, cabin, customer, etc.)
   └── data/seed-data.ts # Default seed payloads (settings, etc.)
@@ -266,9 +267,17 @@ const data = validationResult.data;
 - `HTTP_STATUS` — Named status code constants
 
 **Rate Limiting** (`lib/rate-limit.ts`):
-- In-memory limiter suitable for single-instance / dev deployments
+- **Dual-mode.** When `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are both set, limits are enforced **globally** across serverless instances via `@upstash/ratelimit`. Without them (local dev, tests, CI) it falls back to a module-level `Map`, which is **per-instance** and only meaningful for single-instance deployments. Both modes use a fixed window, so the semantics match.
+- `checkRateLimit()` is **async** (`Promise<RateLimitResult>`) — always `await` it. `checkRateLimitInMemory()` is the sync fallback, exported for tests only.
+- If a configured Redis is unreachable, the check **fails open**: the request is allowed and `logger.error` records it. An Upstash outage degrades to "no rate limiting" rather than 429-ing every request.
 - Preset configs: `MUTATION`, `EMAIL`, `CUSTOMER_CREATE`, `BOOKING_CREATE`, `AUTH`
-- Applied on email send (`app/api/send/confirm`, `app/api/send/welcome`) and customer-create (`app/api/customers` POST); use `checkRateLimit()` + `createRateLimitKey()` for new sensitive routes. Note: the `BOOKING_CREATE` preset exists but is not yet wired into `app/api/bookings` — apply it there if booking creation needs rate limiting.
+- Applied on email send (`app/api/send/confirm`, `app/api/send/welcome`) and customer-create (`app/api/customers` POST); use `await checkRateLimit()` + `createRateLimitKey()` for new sensitive routes. Note: the `BOOKING_CREATE` preset exists but is not yet wired into `app/api/bookings` — apply it there if booking creation needs rate limiting.
+
+**Distributed State** (`lib/redis.ts`):
+- `getRedisClient()` returns a memoized `@upstash/redis` client, or `null` when the two `UPSTASH_REDIS_REST_*` vars are absent. Every consumer must handle `null` with an in-memory fallback so local development needs no Redis.
+- `REDIS_KEY_PREFIX` (`lodgeflow`) namespaces all keys. Current consumers: `lodgeflow:ratelimit:*` (`lib/rate-limit.ts`) and `lodgeflow:clerk-user:*` (`lib/clerk-users.ts`).
+- Cache/limiter failures are logged and swallowed — Redis is never on the critical path for correctness.
+- `resetRedisClient()` clears the memoized client; test-only, for suites that toggle the env vars.
 
 **Logging** (`lib/logger.ts`):
 - Use `logger.info/warn/error/debug()` instead of raw `console.*` in server code
@@ -418,6 +427,20 @@ from the `Cabin` and `Settings` documents — never from the request body. It th
 ### Clerk Rate Limiting
 API has concurrent call limits. Clerk user batch fetching uses `CLERK_API_CONCURRENT_LIMIT` env var (defaults to 3) in `lib/clerk-users.ts`.
 
+`getClerkUser()` / `getClerkUsersBatch()` cache resolved `Customer` objects for 5 minutes,
+in Redis when Upstash is configured and in a module-level `Map` otherwise (see **Distributed
+State** above). Two details matter when touching this cache:
+- The payload is wrapped as `{ data: Customer | null }` so a cached "user was deleted" (`null`)
+  stays distinguishable from a cache miss (Redis returns `null` for an absent key). Only a
+  genuine 404 is cached as `null`; transient 429/5xx errors are never cached.
+- JSON has no `Date`, so `reviveCustomerDates()` rehydrates `created_at`, `updated_at`,
+  `last_sign_in_at`, `last_active_at`, and `lastBookingDate` on every Redis read. Add any new
+  `Date` field on `Customer` to that function.
+
+The 100 ms `MIN_REQUEST_INTERVAL` throttle in `waitForRateLimit()` is still per-instance by
+design — it paces this process's own Clerk calls, and moving it to Redis would add a round trip
+per Clerk request.
+
 ### Environment Variables Required
 No `.env.example` is checked into the repo (`.env*` is gitignored) — set these directly in `.env.local`. Minimum for local development:
 ```bash
@@ -433,6 +456,14 @@ Optional:
 CLERK_API_CONCURRENT_LIMIT=3   # Clerk batch fetch concurrency (default: 3)
 TESTING_AUTH_BYPASS=true       # Server-only auth bypass (dev only)
 NEXT_PUBLIC_TESTING=true       # Client UX bypass for AuthGuard (dev only)
+
+# Upstash Redis — set BOTH to enable distributed rate limiting and a shared
+# Clerk user cache. Omit both for the in-memory fallback. Required in any
+# multi-instance deployment (i.e. production on Vercel), where per-instance
+# state means rate limits are silently multiplied by the number of warm
+# instances. Provision via the Vercel Marketplace.
+UPSTASH_REDIS_REST_URL=https://...upstash.io
+UPSTASH_REDIS_REST_TOKEN=...
 ```
 
 ### Auth Bypass for Testing

--- a/__tests__/unit/lib/clerk-users.redis-cache.test.ts
+++ b/__tests__/unit/lib/clerk-users.redis-cache.test.ts
@@ -1,0 +1,315 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Mocks are hoisted above the imports, so the factories below reference the
+// `mock*` bindings lazily (inside arrow functions) to avoid a TDZ error.
+const mockGetUser = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+  clerkClient: jest.fn().mockResolvedValue({
+    users: {
+      getUser: (...args: any[]) => mockGetUser(...args),
+      getUserList: jest.fn(),
+      updateUser: jest.fn(),
+      updateUserMetadata: jest.fn(),
+      deleteUser: jest.fn(),
+    },
+  }),
+  User: {},
+}));
+
+const mockRedisGet = jest.fn();
+const mockRedisSet = jest.fn();
+const mockRedisMget = jest.fn();
+const mockRedisDel = jest.fn();
+
+jest.mock('@upstash/redis', () => ({
+  Redis: jest.fn().mockImplementation(() => ({
+    get: (...args: any[]) => mockRedisGet(...args),
+    set: (...args: any[]) => mockRedisSet(...args),
+    mget: (...args: any[]) => mockRedisMget(...args),
+    del: (...args: any[]) => mockRedisDel(...args),
+  })),
+}));
+
+import {
+  getClerkUser,
+  getClerkUsersBatch,
+  resetUserCache,
+} from '@/lib/clerk-users';
+import { resetRedisClient } from '@/lib/redis';
+
+const CACHE_DURATION_MS = 5 * 60 * 1000;
+
+function enableRedis(): void {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  resetRedisClient();
+}
+
+function disableRedis(): void {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  resetRedisClient();
+}
+
+let uniqueCounter = 0;
+function uid(prefix = 'user'): string {
+  uniqueCounter++;
+  return `${prefix}_${Date.now()}_${uniqueCounter}`;
+}
+
+function clerkUser(id: string, overrides: Record<string, any> = {}) {
+  return {
+    id,
+    firstName: 'Test',
+    lastName: 'User',
+    username: null,
+    emailAddresses: [{ id: 'email_1', emailAddress: `${id}@example.com` }],
+    primaryEmailAddressId: 'email_1',
+    phoneNumbers: [],
+    imageUrl: '',
+    hasImage: false,
+    publicMetadata: {},
+    privateMetadata: {},
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    lastSignInAt: null,
+    lastActiveAt: Date.now(),
+    banned: false,
+    locked: false,
+    ...overrides,
+  };
+}
+
+/** A cache entry as it comes back from Redis: JSON, so Dates are ISO strings. */
+function redisEntry(id: string, overrides: Record<string, any> = {}) {
+  return {
+    data: {
+      id,
+      username: null,
+      first_name: 'Cached',
+      last_name: 'User',
+      name: 'Cached User',
+      email: `${id}@example.com`,
+      image_url: '',
+      has_image: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+      last_sign_in_at: null,
+      last_active_at: '2026-01-03T00:00:00.000Z',
+      banned: false,
+      locked: false,
+      lockout_expires_in_seconds: null,
+      totalBookings: 0,
+      totalSpent: 0,
+      loyaltyTier: 'Bronze',
+      fullAddress: '',
+      ...overrides,
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetUserCache();
+  enableRedis();
+  mockRedisSet.mockResolvedValue('OK');
+  mockRedisDel.mockResolvedValue(1);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  disableRedis();
+  jest.restoreAllMocks();
+});
+
+describe('getClerkUser — Redis-backed cache', () => {
+  it('serves a hit from Redis without calling Clerk', async () => {
+    const id = uid();
+    mockRedisGet.mockResolvedValue(redisEntry(id));
+
+    const customer = await getClerkUser(id);
+
+    expect(mockRedisGet).toHaveBeenCalledWith(`lodgeflow:clerk-user:${id}`);
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(customer?.id).toBe(id);
+    expect(customer?.name).toBe('Cached User');
+  });
+
+  it('revives Date fields that JSON serialization flattened to strings', async () => {
+    const id = uid();
+    mockRedisGet.mockResolvedValue(
+      redisEntry(id, { last_sign_in_at: '2026-01-04T00:00:00.000Z' })
+    );
+
+    const customer = await getClerkUser(id);
+
+    expect(customer!.created_at).toBeInstanceOf(Date);
+    expect(customer!.updated_at).toBeInstanceOf(Date);
+    expect(customer!.last_active_at).toBeInstanceOf(Date);
+    expect(customer!.last_sign_in_at).toBeInstanceOf(Date);
+    expect(customer!.created_at.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('keeps a null last_sign_in_at as null rather than an Invalid Date', async () => {
+    const id = uid();
+    mockRedisGet.mockResolvedValue(redisEntry(id));
+
+    const customer = await getClerkUser(id);
+
+    expect(customer!.last_sign_in_at).toBeNull();
+  });
+
+  it('writes through to Redis with the 5-minute TTL on a miss', async () => {
+    const id = uid();
+    mockRedisGet.mockResolvedValue(null);
+    mockGetUser.mockResolvedValue(clerkUser(id));
+
+    await getClerkUser(id);
+
+    expect(mockGetUser).toHaveBeenCalledWith(id);
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      `lodgeflow:clerk-user:${id}`,
+      expect.objectContaining({ data: expect.objectContaining({ id }) }),
+      { px: CACHE_DURATION_MS }
+    );
+  });
+
+  it('distinguishes a cached "user does not exist" from a cache miss', async () => {
+    const id = uid();
+    // The wrapper object is present but its payload is null.
+    mockRedisGet.mockResolvedValue({ data: null });
+
+    await expect(getClerkUser(id)).resolves.toBeNull();
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it('caches a 404 as a null payload so the lookup is not retried', async () => {
+    const id = uid();
+    mockRedisGet.mockResolvedValue(null);
+    mockGetUser.mockRejectedValue({ status: 404 });
+
+    await expect(getClerkUser(id)).resolves.toBeNull();
+
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      `lodgeflow:clerk-user:${id}`,
+      { data: null },
+      { px: CACHE_DURATION_MS }
+    );
+  });
+
+  it('does not cache transient Clerk errors', async () => {
+    const id = uid();
+    mockRedisGet.mockResolvedValue(null);
+    mockGetUser.mockRejectedValue({ status: 500 });
+
+    await expect(getClerkUser(id)).rejects.toEqual({ status: 500 });
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it('treats a Redis read failure as a miss and still returns the user', async () => {
+    const id = uid();
+    mockRedisGet.mockRejectedValue(new Error('ECONNREFUSED'));
+    mockGetUser.mockResolvedValue(clerkUser(id));
+
+    const customer = await getClerkUser(id);
+
+    expect(customer?.id).toBe(id);
+    expect(mockGetUser).toHaveBeenCalledWith(id);
+  });
+
+  it('does not fail the request when the Redis write fails', async () => {
+    const id = uid();
+    mockRedisGet.mockResolvedValue(null);
+    mockRedisSet.mockRejectedValue(new Error('quota exceeded'));
+    mockGetUser.mockResolvedValue(clerkUser(id));
+
+    await expect(getClerkUser(id)).resolves.toMatchObject({ id });
+  });
+});
+
+describe('getClerkUsersBatch — Redis-backed cache', () => {
+  it('reads every id in a single mget round trip', async () => {
+    const ids = [uid(), uid(), uid()];
+    mockRedisMget.mockResolvedValue(ids.map(id => redisEntry(id)));
+
+    const { users, errors } = await getClerkUsersBatch(ids);
+
+    expect(mockRedisMget).toHaveBeenCalledTimes(1);
+    expect(mockRedisMget).toHaveBeenCalledWith(
+      ...ids.map(id => `lodgeflow:clerk-user:${id}`)
+    );
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(users.size).toBe(3);
+    expect(errors).toBe(0);
+  });
+
+  it('fetches only the ids that missed the cache', async () => {
+    const cachedId = uid('cached');
+    const freshId = uid('fresh');
+    mockRedisMget.mockResolvedValue([redisEntry(cachedId), null]);
+    mockGetUser.mockResolvedValue(clerkUser(freshId));
+
+    const { users } = await getClerkUsersBatch([cachedId, freshId]);
+
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockGetUser).toHaveBeenCalledWith(freshId);
+    expect(users.get(cachedId)?.name).toBe('Cached User');
+    expect(users.get(freshId)?.id).toBe(freshId);
+  });
+
+  it('honors a cached null payload as "user does not exist"', async () => {
+    const goneId = uid('gone');
+    mockRedisMget.mockResolvedValue([{ data: null }]);
+
+    const { users, errors } = await getClerkUsersBatch([goneId]);
+
+    expect(users.get(goneId)).toBeNull();
+    expect(users.has(goneId)).toBe(true);
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(errors).toBe(0);
+  });
+
+  it('falls back to fetching everything when mget fails', async () => {
+    const id = uid();
+    mockRedisMget.mockRejectedValue(new Error('ECONNREFUSED'));
+    mockGetUser.mockResolvedValue(clerkUser(id));
+
+    const { users, errors } = await getClerkUsersBatch([id]);
+
+    expect(users.get(id)?.id).toBe(id);
+    expect(errors).toBe(0);
+  });
+});
+
+describe('in-memory fallback when Upstash is not configured', () => {
+  beforeEach(() => {
+    disableRedis();
+    resetUserCache();
+  });
+
+  it('caches within the process and never touches Redis', async () => {
+    const id = uid();
+    mockGetUser.mockResolvedValue(clerkUser(id));
+
+    await getClerkUser(id);
+    await getClerkUser(id);
+
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockRedisGet).not.toHaveBeenCalled();
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it('serves the batch path from the in-memory cache', async () => {
+    const id = uid();
+    mockGetUser.mockResolvedValue(clerkUser(id));
+
+    await getClerkUser(id); // populate
+    const { users } = await getClerkUsersBatch([id]);
+
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockRedisMget).not.toHaveBeenCalled();
+    expect(users.get(id)?.id).toBe(id);
+  });
+});

--- a/__tests__/unit/lib/rate-limit.test.ts
+++ b/__tests__/unit/lib/rate-limit.test.ts
@@ -1,0 +1,282 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Mocks are hoisted above the imports, so the factories below reference the
+// `mock*` bindings lazily (inside arrow functions) to avoid a TDZ error.
+const mockRatelimitLimit = jest.fn();
+const mockFixedWindow = jest.fn((limit: number, window: string) => ({
+  limit,
+  window,
+}));
+const mockRatelimitConstructor = jest.fn();
+
+jest.mock('@upstash/ratelimit', () => ({
+  Ratelimit: Object.assign(
+    function Ratelimit(this: any, config: any) {
+      mockRatelimitConstructor(config);
+      this.limit = (...args: any[]) => mockRatelimitLimit(...args);
+    },
+    { fixedWindow: (...args: any[]) => (mockFixedWindow as any)(...args) }
+  ),
+}));
+
+jest.mock('@upstash/redis', () => ({
+  Redis: jest.fn().mockImplementation(() => ({ __upstash: true })),
+}));
+
+import {
+  checkRateLimit,
+  checkRateLimitInMemory,
+  createRateLimitKey,
+  RATE_LIMIT_CONFIGS,
+  resetRateLimitState,
+} from '@/lib/rate-limit';
+import { resetRedisClient } from '@/lib/redis';
+
+const REDIS_ENV = {
+  UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
+  UPSTASH_REDIS_REST_TOKEN: 'test-token',
+};
+
+function enableRedis(): void {
+  Object.assign(process.env, REDIS_ENV);
+  resetRedisClient();
+}
+
+function disableRedis(): void {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  resetRedisClient();
+}
+
+// Each test uses a fresh identifier so it is isolated from earlier records.
+let uniqueCounter = 0;
+function key(prefix = 'rl'): string {
+  uniqueCounter++;
+  return `${prefix}_${Date.now()}_${uniqueCounter}`;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetRateLimitState();
+  disableRedis();
+});
+
+afterEach(() => {
+  disableRedis();
+  jest.useRealTimers();
+});
+
+describe('createRateLimitKey', () => {
+  it('namespaces the key by user and endpoint', () => {
+    expect(createRateLimitKey('user_123', 'send-confirm')).toBe(
+      'user_123:send-confirm'
+    );
+  });
+
+  it('falls back to "anonymous" when there is no user id', () => {
+    expect(createRateLimitKey(undefined, 'send-confirm')).toBe(
+      'anonymous:send-confirm'
+    );
+  });
+});
+
+describe('checkRateLimit — in-memory fallback (Upstash env vars unset)', () => {
+  const config = { limit: 3, windowMs: 60 * 1000 };
+
+  it('allows requests up to the limit and decrements remaining', async () => {
+    const identifier = key();
+
+    const first = await checkRateLimit(identifier, config);
+    expect(first).toMatchObject({ success: true, limit: 3, remaining: 2 });
+
+    const second = await checkRateLimit(identifier, config);
+    expect(second).toMatchObject({ success: true, remaining: 1 });
+
+    const third = await checkRateLimit(identifier, config);
+    expect(third).toMatchObject({ success: true, remaining: 0 });
+  });
+
+  it('blocks the request that exceeds the limit', async () => {
+    const identifier = key();
+    for (let i = 0; i < config.limit; i++) {
+      await checkRateLimit(identifier, config);
+    }
+
+    const blocked = await checkRateLimit(identifier, config);
+    expect(blocked.success).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.resetTime).toBeGreaterThan(Date.now());
+  });
+
+  it('tracks identifiers independently', async () => {
+    const a = key('a');
+    const b = key('b');
+
+    for (let i = 0; i < config.limit; i++) {
+      await checkRateLimit(a, config);
+    }
+
+    expect((await checkRateLimit(a, config)).success).toBe(false);
+    expect((await checkRateLimit(b, config)).success).toBe(true);
+  });
+
+  it('starts a new window once the previous one expires', async () => {
+    const identifier = key();
+    const nowSpy = jest.spyOn(Date, 'now');
+    const start = 1_000_000;
+
+    nowSpy.mockReturnValue(start);
+    for (let i = 0; i < config.limit; i++) {
+      await checkRateLimit(identifier, config);
+    }
+    expect((await checkRateLimit(identifier, config)).success).toBe(false);
+
+    // Advance past the window boundary.
+    nowSpy.mockReturnValue(start + config.windowMs + 1);
+    const afterReset = await checkRateLimit(identifier, config);
+    expect(afterReset).toMatchObject({ success: true, remaining: 2 });
+
+    nowSpy.mockRestore();
+  });
+
+  it('defaults to the MUTATION config', async () => {
+    const result = await checkRateLimit(key());
+    expect(result.limit).toBe(RATE_LIMIT_CONFIGS.MUTATION.limit);
+  });
+
+  it('does not construct an Upstash limiter', async () => {
+    await checkRateLimit(key(), config);
+    expect(mockRatelimitConstructor).not.toHaveBeenCalled();
+    expect(mockRatelimitLimit).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkRateLimitInMemory', () => {
+  it('is unaffected by Upstash being configured', () => {
+    enableRedis();
+    const identifier = key();
+
+    const result = checkRateLimitInMemory(identifier, {
+      limit: 1,
+      windowMs: 60_000,
+    });
+
+    expect(result).toMatchObject({ success: true, remaining: 0 });
+    expect(mockRatelimitLimit).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkRateLimit — distributed store selection (Upstash env vars set)', () => {
+  const config = { limit: 5, windowMs: 60 * 1000 };
+
+  beforeEach(() => {
+    enableRedis();
+  });
+
+  it('routes the check through @upstash/ratelimit instead of the local Map', async () => {
+    const reset = Date.now() + 60_000;
+    mockRatelimitLimit.mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset,
+    });
+
+    const identifier = key();
+    const result = await checkRateLimit(identifier, config);
+
+    expect(mockRatelimitLimit).toHaveBeenCalledWith(identifier);
+    expect(result).toEqual({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      resetTime: reset,
+    });
+  });
+
+  it('builds a fixed window matching the config and namespaces the keys', async () => {
+    mockRatelimitLimit.mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now(),
+    });
+
+    await checkRateLimit(key(), config);
+
+    expect(mockFixedWindow).toHaveBeenCalledWith(5, '60000 ms');
+    expect(mockRatelimitConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ prefix: 'lodgeflow:ratelimit' })
+    );
+  });
+
+  it('reuses one limiter per config instead of rebuilding it each call', async () => {
+    mockRatelimitLimit.mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now(),
+    });
+
+    await checkRateLimit(key(), config);
+    await checkRateLimit(key(), config);
+    await checkRateLimit(key(), config);
+
+    expect(mockRatelimitConstructor).toHaveBeenCalledTimes(1);
+    expect(mockRatelimitLimit).toHaveBeenCalledTimes(3);
+  });
+
+  it('builds a separate limiter for a different config', async () => {
+    mockRatelimitLimit.mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now(),
+    });
+
+    await checkRateLimit(key(), RATE_LIMIT_CONFIGS.EMAIL);
+    await checkRateLimit(key(), RATE_LIMIT_CONFIGS.CUSTOMER_CREATE);
+
+    expect(mockRatelimitConstructor).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates a denial from the distributed store', async () => {
+    const reset = Date.now() + 30_000;
+    mockRatelimitLimit.mockResolvedValue({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      reset,
+    });
+
+    const result = await checkRateLimit(key(), config);
+
+    expect(result).toEqual({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      resetTime: reset,
+    });
+  });
+
+  it('fails open when Redis is unreachable', async () => {
+    mockRatelimitLimit.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await checkRateLimit(key(), config);
+
+    expect(result.success).toBe(true);
+    expect(result.limit).toBe(config.limit);
+    // No counter was incremented, so the full budget is reported.
+    expect(result.remaining).toBe(config.limit);
+    expect(result.resetTime).toBeGreaterThan(Date.now());
+  });
+
+  it('keeps failing open on repeated Redis errors rather than blocking traffic', async () => {
+    mockRatelimitLimit.mockRejectedValue(new Error('ECONNREFUSED'));
+    const identifier = key();
+
+    for (let i = 0; i < 10; i++) {
+      expect((await checkRateLimit(identifier, config)).success).toBe(true);
+    }
+  });
+});

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -143,7 +143,7 @@ export async function POST(request: NextRequest) {
 
   // Rate limit customer creation
   const rateLimitKey = createRateLimitKey(authResult.userId, 'customer-create');
-  const rateLimitResult = checkRateLimit(
+  const rateLimitResult = await checkRateLimit(
     rateLimitKey,
     RATE_LIMIT_CONFIGS.CUSTOMER_CREATE
   );

--- a/app/api/send/confirm/route.ts
+++ b/app/api/send/confirm/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
 
   // Rate limit email sending (stricter limits)
   const rateLimitKey = createRateLimitKey(authResult.userId, 'send-confirm');
-  const rateLimitResult = checkRateLimit(
+  const rateLimitResult = await checkRateLimit(
     rateLimitKey,
     RATE_LIMIT_CONFIGS.EMAIL
   );

--- a/app/api/send/welcome/route.ts
+++ b/app/api/send/welcome/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
 
   // Rate limit email sending (stricter limits)
   const rateLimitKey = createRateLimitKey(authResult.userId, 'send-welcome');
-  const rateLimitResult = checkRateLimit(
+  const rateLimitResult = await checkRateLimit(
     rateLimitKey,
     RATE_LIMIT_CONFIGS.EMAIL
   );

--- a/lib/clerk-users.ts
+++ b/lib/clerk-users.ts
@@ -6,7 +6,12 @@ import type {
 } from '@/types';
 import { clerkClient, User } from '@clerk/nextjs/server';
 
-// In-memory cache for Clerk user data
+import { logger } from '@/lib/logger';
+import { getRedisClient, REDIS_KEY_PREFIX } from '@/lib/redis';
+
+// In-memory cache for Clerk user data. Only used when Upstash is not
+// configured — see lib/redis.ts for why per-instance state is not enough in
+// production.
 const userCache = new Map<
   string,
   { data: Customer | null; timestamp: number }
@@ -18,9 +23,67 @@ let lastRequestTime = 0;
 const MIN_REQUEST_INTERVAL = 100; // Minimum 100ms between requests
 
 /**
- * Simple cache management
+ * Redis-serialized cache entry. The `Customer | null` payload is wrapped in an
+ * object so a cached "user does not exist" (`null`) stays distinguishable from
+ * a cache miss (Redis returns `null` for an absent key).
  */
-function getCachedUser(userId: string): Customer | null | undefined {
+interface CachedCustomerEntry {
+  data: Customer | null;
+}
+
+function userCacheKey(userId: string): string {
+  return `${REDIS_KEY_PREFIX}:clerk-user:${userId}`;
+}
+
+/**
+ * JSON has no Date type, so every `Date` field survives the Redis round trip as
+ * an ISO string. Rehydrate them to keep the cached `Customer` shape identical
+ * to a freshly converted one.
+ */
+function reviveCustomerDates(customer: Customer): Customer {
+  const toDate = (value: unknown): Date | null =>
+    value == null ? null : new Date(value as string);
+
+  return {
+    ...customer,
+    created_at: toDate(customer.created_at) as Date,
+    updated_at: toDate(customer.updated_at) as Date,
+    last_sign_in_at: toDate(customer.last_sign_in_at),
+    last_active_at: toDate(customer.last_active_at) as Date,
+    lastBookingDate: customer.lastBookingDate
+      ? new Date(customer.lastBookingDate)
+      : undefined,
+  };
+}
+
+function entryToCustomer(entry: CachedCustomerEntry): Customer | null {
+  return entry.data ? reviveCustomerDates(entry.data) : null;
+}
+
+/**
+ * Read one user from the cache.
+ *
+ * @returns the cached `Customer`, `null` when the user is cached as
+ * non-existent, or `undefined` on a miss/expiry. Redis errors are logged and
+ * reported as a miss so a cache outage never fails the request.
+ */
+async function getCachedUser(
+  userId: string
+): Promise<Customer | null | undefined> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      const entry = await redis.get<CachedCustomerEntry>(userCacheKey(userId));
+      return entry ? entryToCustomer(entry) : undefined;
+    } catch (error) {
+      logger.error('Redis user cache read failed, treating as miss', error, {
+        userId,
+      });
+      return undefined;
+    }
+  }
+
   const cached = userCache.get(userId);
   if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
     return cached.data;
@@ -28,15 +91,96 @@ function getCachedUser(userId: string): Customer | null | undefined {
   return undefined; // Not in cache or expired
 }
 
-function setCachedUser(userId: string, user: Customer | null): void {
+/**
+ * Read many users from the cache in a single round trip.
+ *
+ * Only hits are present in the returned map; a `null` value means the user is
+ * cached as non-existent.
+ */
+async function getCachedUsers(
+  userIds: string[]
+): Promise<Map<string, Customer | null>> {
+  const results = new Map<string, Customer | null>();
+  if (userIds.length === 0) return results;
+
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      const entries = await redis.mget<(CachedCustomerEntry | null)[]>(
+        ...userIds.map(userCacheKey)
+      );
+
+      entries.forEach((entry, index) => {
+        if (entry) results.set(userIds[index], entryToCustomer(entry));
+      });
+
+      return results;
+    } catch (error) {
+      logger.error('Redis user cache read failed, treating as miss', error, {
+        count: userIds.length,
+      });
+      return results;
+    }
+  }
+
+  for (const userId of userIds) {
+    const cached = userCache.get(userId);
+    if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+      results.set(userId, cached.data);
+    }
+  }
+
+  return results;
+}
+
+async function setCachedUser(
+  userId: string,
+  user: Customer | null
+): Promise<void> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      await redis.set<CachedCustomerEntry>(
+        userCacheKey(userId),
+        { data: user },
+        { px: CACHE_DURATION }
+      );
+    } catch (error) {
+      // A failed write only costs a future cache miss.
+      logger.error('Redis user cache write failed', error, { userId });
+    }
+    return;
+  }
+
   userCache.set(userId, { data: user, timestamp: Date.now() });
 }
 
 /**
  * Invalidate cache for a specific user
  */
-function invalidateCache(userId: string): void {
+async function invalidateCache(userId: string): Promise<void> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      await redis.del(userCacheKey(userId));
+    } catch (error) {
+      // Leaving a stale entry is bounded by the 5-minute TTL.
+      logger.error('Redis user cache invalidation failed', error, { userId });
+    }
+    return;
+  }
+
   userCache.delete(userId);
+}
+
+/**
+ * Clear the in-memory user cache. Test-only.
+ */
+export function resetUserCache(): void {
+  userCache.clear();
 }
 
 /**
@@ -227,7 +371,7 @@ export async function getClerkUsers(params: ClerkUserListParams = {}): Promise<{
  */
 export async function getClerkUser(userId: string): Promise<Customer | null> {
   // Check cache first
-  const cachedUser = getCachedUser(userId);
+  const cachedUser = await getCachedUser(userId);
   if (cachedUser !== undefined) {
     return cachedUser;
   }
@@ -243,7 +387,7 @@ export async function getClerkUser(userId: string): Promise<Customer | null> {
     });
 
     // Cache the result
-    setCachedUser(userId, customer);
+    await setCachedUser(userId, customer);
 
     return customer;
   } catch (error: unknown) {
@@ -260,7 +404,7 @@ export async function getClerkUser(userId: string): Promise<Customer | null> {
         typedError.status === 404 ||
         typedError.errors?.[0]?.code === 'resource_not_found'
       ) {
-        setCachedUser(userId, null);
+        await setCachedUser(userId, null);
         return null;
       }
     }
@@ -295,11 +439,11 @@ export async function getClerkUsersBatch(
   const uncachedIds: string[] = [];
   let errorCount = 0;
 
-  // Check cache first for all IDs
+  // Check cache first for all IDs (a single round trip when Redis-backed)
+  const cachedUsers = await getCachedUsers(userIds);
   for (const userId of userIds) {
-    const cached = getCachedUser(userId);
-    if (cached !== undefined) {
-      results.set(userId, cached);
+    if (cachedUsers.has(userId)) {
+      results.set(userId, cachedUsers.get(userId) ?? null);
     } else {
       uncachedIds.push(userId);
     }
@@ -326,7 +470,7 @@ export async function getClerkUsersBatch(
           const clerkUser = await client.users.getUser(userId);
           const customer = convertClerkUserToCustomer(clerkUser);
 
-          setCachedUser(userId, customer);
+          await setCachedUser(userId, customer);
           return { userId, customer, failed: false };
         } catch (error: unknown) {
           console.error(`Error fetching user ${userId}:`, error);
@@ -341,7 +485,7 @@ export async function getClerkUsersBatch(
           // Transient errors (429, 500+, network) should NOT be cached
           // so they can be retried on the next request.
           if (is404) {
-            setCachedUser(userId, null);
+            await setCachedUser(userId, null);
           }
 
           return { userId, customer: null, failed: !is404 };
@@ -611,7 +755,7 @@ export async function deleteCompleteCustomer(
 ): Promise<void> {
   try {
     await deleteClerkUser(clerkUserId);
-    invalidateCache(clerkUserId);
+    await invalidateCache(clerkUserId);
   } catch (error) {
     console.error('Error deleting complete customer:', error);
     throw error;
@@ -710,7 +854,7 @@ export async function updateCompleteCustomer(
     }
 
     // Invalidate cache
-    invalidateCache(clerkUserId);
+    await invalidateCache(clerkUserId);
 
     // 3. Return updated combined customer object
     if (!clerkUser) {

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,15 +1,20 @@
 /**
- * Simple in-memory rate limiter
+ * Dual-mode rate limiter.
  *
- * For production, consider using:
- * - @upstash/ratelimit with @upstash/redis for distributed rate limiting
- * - Redis-based solutions for multi-instance deployments
+ * - **Distributed (production):** when `UPSTASH_REDIS_REST_URL` and
+ *   `UPSTASH_REDIS_REST_TOKEN` are set, limits are enforced globally via
+ *   `@upstash/ratelimit` so they hold across serverless instances.
+ * - **In-memory (local development, tests):** without those variables, limits
+ *   fall back to a module-level `Map`. That store is per-instance, so it is
+ *   only meaningful for single-instance deployments.
  *
- * This implementation is suitable for:
- * - Development environments
- * - Single-instance deployments
- * - Low-traffic applications
+ * Both modes use a fixed window, so their semantics match.
  */
+
+import { Ratelimit } from '@upstash/ratelimit';
+
+import { logger } from '@/lib/logger';
+import { getRedisClient, REDIS_KEY_PREFIX } from '@/lib/redis';
 
 interface RateLimitRecord {
   count: number;
@@ -74,13 +79,82 @@ export const RATE_LIMIT_CONFIGS = {
 } as const;
 
 /**
- * Check if a request should be rate limited
+ * Cached `Ratelimit` instances keyed by `limit:windowMs`. Constructing one per
+ * request would rebuild the underlying scripts on every call.
+ */
+const limiterCache = new Map<string, Ratelimit>();
+
+function getDistributedLimiter(
+  redis: NonNullable<ReturnType<typeof getRedisClient>>,
+  config: RateLimitConfig
+): Ratelimit {
+  const cacheKey = `${config.limit}:${config.windowMs}`;
+  const cached = limiterCache.get(cacheKey);
+  if (cached) return cached;
+
+  const limiter = new Ratelimit({
+    redis,
+    // Fixed window matches the in-memory fallback's semantics.
+    limiter: Ratelimit.fixedWindow(config.limit, `${config.windowMs} ms`),
+    prefix: `${REDIS_KEY_PREFIX}:ratelimit`,
+  });
+
+  limiterCache.set(cacheKey, limiter);
+  return limiter;
+}
+
+/**
+ * Check if a request should be rate limited.
+ *
+ * Uses Redis when Upstash is configured, otherwise the in-memory store. If a
+ * configured Redis is unreachable the check **fails open** — the request is
+ * allowed and the error is logged, so an Upstash outage degrades to "no rate
+ * limiting" rather than taking the endpoint down.
  *
  * @param identifier - Unique identifier for the rate limit (e.g., userId, IP address)
  * @param config - Rate limit configuration
  * @returns Rate limit result with success status and metadata
  */
-export function checkRateLimit(
+export async function checkRateLimit(
+  identifier: string,
+  config: RateLimitConfig = RATE_LIMIT_CONFIGS.MUTATION
+): Promise<RateLimitResult> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      const { success, remaining, reset } = await getDistributedLimiter(
+        redis,
+        config
+      ).limit(identifier);
+
+      return { success, limit: config.limit, remaining, resetTime: reset };
+    } catch (error) {
+      logger.error(
+        'Distributed rate limit check failed, allowing request',
+        error,
+        { identifier }
+      );
+
+      // Fail open. No counter was incremented, so report the full budget.
+      return {
+        success: true,
+        limit: config.limit,
+        remaining: config.limit,
+        resetTime: Date.now() + config.windowMs,
+      };
+    }
+  }
+
+  return checkRateLimitInMemory(identifier, config);
+}
+
+/**
+ * In-memory fallback used when Upstash is not configured.
+ *
+ * Exported for tests; production code should call `checkRateLimit()`.
+ */
+export function checkRateLimitInMemory(
   identifier: string,
   config: RateLimitConfig = RATE_LIMIT_CONFIGS.MUTATION
 ): RateLimitResult {
@@ -134,4 +208,14 @@ export function createRateLimitKey(
   endpoint: string
 ): string {
   return `${userId || 'anonymous'}:${endpoint}`;
+}
+
+/**
+ * Clear both the in-memory records and the cached `Ratelimit` instances.
+ * Test-only — lets a suite switch between the distributed and in-memory paths.
+ */
+export function resetRateLimitState(): void {
+  rateLimitStore.clear();
+  limiterCache.clear();
+  lastCleanup = Date.now();
 }

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared Upstash Redis client for cross-instance state.
+ *
+ * Vercel runs each request on a potentially different serverless instance, so
+ * module-level `Map`s are per-instance and cannot back a global rate limit or a
+ * shared cache. When `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`
+ * are both set, callers get a Redis client and use the distributed path; when
+ * either is missing (local development, tests) `getRedisClient()` returns
+ * `null` and callers fall back to their in-memory implementation.
+ */
+
+import { Redis } from '@upstash/redis';
+
+/** Key namespace so LodgeFlow keys never collide with other apps on the DB. */
+export const REDIS_KEY_PREFIX = 'lodgeflow';
+
+// `undefined` means "not resolved yet", `null` means "resolved: not configured".
+let cachedClient: Redis | null | undefined;
+
+/**
+ * Get the shared Redis client, or `null` when Upstash is not configured.
+ *
+ * The result is memoized, so changing the environment variables at runtime has
+ * no effect until the process restarts (or `resetRedisClient()` is called).
+ */
+export function getRedisClient(): Redis | null {
+  if (cachedClient !== undefined) return cachedClient;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  cachedClient = url && token ? new Redis({ url, token }) : null;
+
+  return cachedClient;
+}
+
+/**
+ * Whether distributed state is available in this environment.
+ */
+export function isRedisConfigured(): boolean {
+  return getRedisClient() !== null;
+}
+
+/**
+ * Clear the memoized client. Test-only — lets a suite toggle the environment
+ * variables between the distributed and in-memory code paths.
+ */
+export function resetRedisClient(): void {
+  cachedClient = undefined;
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "@react-aria/visually-hidden": "3.8.29",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-devtools": "^5.91.2",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.1",
     "clsx": "2.1.1",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.33.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/nextjs':
         specifier: ^6.36.7
-        version: 6.39.5(next@16.2.10(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.39.5(next@16.2.10(@babel/core@7.29.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/themes':
         specifier: ^2.4.47
         version: 2.4.57(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -131,6 +131,12 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.91.2
         version: 5.101.2(@tanstack/react-query@5.101.2(react@18.3.1))(react@18.3.1)
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.1)
+      '@upstash/redis':
+        specifier: ^1.38.1
+        version: 1.38.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -157,10 +163,10 @@ importers:
         version: 0.562.0(react@18.3.1)
       mongoose:
         specifier: ^8.20.1
-        version: 8.24.1
+        version: 8.24.1(supports-color@8.1.1)
       next:
         specifier: 16.2.10
-        version: 16.2.10(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.2.10(@babel/core@7.29.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -185,10 +191,10 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.1
-        version: 2.1.0(eslint@9.39.2(jiti@2.7.0))
+        version: 2.1.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       '@eslint/eslintrc':
         specifier: ^3.3.3
-        version: 3.3.5
+        version: 3.3.5(supports-color@8.1.1)
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.4
@@ -227,40 +233,40 @@ importers:
         version: 18.3.0
       '@typescript-eslint/eslint-plugin':
         specifier: 8.53.0
-        version: 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 8.53.0
-        version: 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint:
         specifier: 9.39.2
-        version: 9.39.2(jiti@2.7.0)
+        version: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       eslint-config-next:
         specifier: 16.1.1
-        version: 16.1.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.1.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@9.39.2(jiti@2.7.0))
+        version: 10.1.8(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+        version: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-jsx-a11y:
         specifier: 6.10.2
-        version: 6.10.2(eslint@9.39.2(jiti@2.7.0))
+        version: 6.10.2(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-node:
         specifier: 11.1.0
-        version: 11.1.0(eslint@9.39.2(jiti@2.7.0))
+        version: 11.1.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-prettier:
         specifier: 5.5.4
-        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))(prettier@3.7.4)
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.7.4)
       eslint-plugin-react:
         specifier: 7.37.5
-        version: 7.37.5(eslint@9.39.2(jiti@2.7.0))
+        version: 7.37.5(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-react-hooks:
         specifier: 7.0.1
-        version: 7.0.1(eslint@9.39.2(jiti@2.7.0))
+        version: 7.0.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-unused-imports:
         specifier: 4.3.0
-        version: 4.3.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))
+        version: 4.3.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       globals:
         specifier: 17.0.0
         version: 17.0.0
@@ -269,16 +275,16 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^30.2.0
-        version: 30.4.2(@types/node@22.15.29)
+        version: 30.4.2(@types/node@22.15.29)(supports-color@8.1.1)
       jest-environment-jsdom:
         specifier: ^30.2.0
-        version: 30.4.1
+        version: 30.4.1(supports-color@8.1.1)
       lint-staged:
         specifier: ^16.2.7
         version: 16.4.0
       mongodb-memory-server:
         specifier: ^11.0.1
-        version: 11.2.0
+        version: 11.2.0(supports-color@8.1.1)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -293,7 +299,7 @@ importers:
         version: 4.1.18
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@22.15.29))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7(supports-color@8.1.1))(@jest/transform@30.4.1(supports-color@8.1.1))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.15.29)(supports-color@8.1.1))(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.23.0
@@ -3128,6 +3134,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.1':
+    resolution: {integrity: sha512-hVqkWmhqobH7hpdzSCSrOwK7gWNASOAdf85l6/yxdB+giCYNYfl8FkSKxnqW2sqCdLDP7HzRTvy/ILC1AjBMUA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -5757,6 +5775,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -5990,20 +6011,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6028,19 +6049,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6061,89 +6082,89 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
@@ -6154,7 +6175,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -6162,7 +6183,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6190,13 +6211,13 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
 
-  '@clerk/nextjs@6.39.5(next@16.2.10(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/nextjs@6.39.5(next@16.2.10(@babel/core@7.29.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 2.33.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/clerk-react': 5.61.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 3.47.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/types': 4.101.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      next: 16.2.10(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.10(@babel/core@7.29.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       server-only: 0.0.1
@@ -6348,23 +6369,23 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.1.0(eslint@9.39.2(jiti@2.7.0))':
+  '@eslint/compat@2.1.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -6381,10 +6402,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@8.1.1)':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -7649,13 +7670,13 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2':
+  '@jest/core@30.4.2(supports-color@8.1.1)':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
-      '@jest/reporters': 30.4.1
+      '@jest/reporters': 30.4.1(supports-color@8.1.1)
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@types/node': 22.15.29
       ansi-escapes: 4.3.2
@@ -7665,15 +7686,15 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@22.15.29)
+      jest-config: 30.4.2(@types/node@22.15.29)(supports-color@8.1.1)
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-resolve-dependencies: 30.4.2
-      jest-runner: 30.4.2
-      jest-runtime: 30.4.2
-      jest-snapshot: 30.4.1
+      jest-resolve-dependencies: 30.4.2(supports-color@8.1.1)
+      jest-runner: 30.4.2(supports-color@8.1.1)
+      jest-runtime: 30.4.2(supports-color@8.1.1)
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       jest-watcher: 30.4.1
@@ -7687,7 +7708,7 @@ snapshots:
 
   '@jest/diff-sequences@30.4.0': {}
 
-  '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
+  '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0(supports-color@8.1.1))':
     dependencies:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
@@ -7696,7 +7717,7 @@ snapshots:
       '@types/node': 22.15.29
       jest-mock: 30.4.1
       jest-util: 30.4.1
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
 
   '@jest/environment@30.4.1':
     dependencies:
@@ -7709,10 +7730,10 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect@30.4.1':
+  '@jest/expect@30.4.1(supports-color@8.1.1)':
     dependencies:
       expect: 30.4.1
-      jest-snapshot: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7727,10 +7748,10 @@ snapshots:
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@30.4.1':
+  '@jest/globals@30.4.1(supports-color@8.1.1)':
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1
+      '@jest/expect': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       jest-mock: 30.4.1
     transitivePeerDependencies:
@@ -7741,12 +7762,12 @@ snapshots:
       '@types/node': 22.15.29
       jest-regex-util: 30.4.0
 
-  '@jest/reporters@30.4.1':
+  '@jest/reporters@30.4.1(supports-color@8.1.1)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 30.4.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 22.15.29
@@ -7756,9 +7777,9 @@ snapshots:
       glob: 10.5.0
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@8.1.1)
       istanbul-reports: 3.2.0
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -7800,12 +7821,12 @@ snapshots:
       jest-haste-map: 30.4.1
       slash: 3.0.0
 
-  '@jest/transform@30.4.1':
+  '@jest/transform@30.4.1(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 7.0.1
+      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -9522,15 +9543,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.53.0
-      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.0
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -9538,15 +9559,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/type-utils': 8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -9554,44 +9575,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
-      '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.53.0(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.0
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.7.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.7.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.53.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.53.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.53.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.63.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.63.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9614,25 +9635,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.53.0
-      '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.53.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9642,13 +9663,13 @@ snapshots:
 
   '@typescript-eslint/types@8.63.0': {}
 
-  '@typescript-eslint/typescript-estree@8.53.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.53.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.53.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.53.0(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/visitor-keys': 8.53.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 9.0.9
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -9657,13 +9678,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.63.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.63.0(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -9672,24 +9693,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
-      '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.53.0(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9775,6 +9796,19 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.1
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.1)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.1
+
+  '@upstash/redis@1.38.1':
+    dependencies:
+      uncrypto: 0.1.3
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -9917,25 +9951,25 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-jest@30.4.1(@babel/core@7.29.7):
+  babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
-      '@jest/transform': 30.4.1
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.4.0(@babel/core@7.29.7)
+      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
+      babel-preset-jest: 30.4.0(@babel/core@7.29.7(supports-color@8.1.1))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@7.0.1:
+  babel-plugin-istanbul@7.0.1(supports-color@8.1.1):
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -9944,30 +9978,30 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
 
-  babel-preset-jest@30.4.0(@babel/core@7.29.7):
+  babel-preset-jest@30.4.0(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       babel-plugin-jest-hoist: 30.4.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@8.1.1))
 
   balanced-match@1.0.2: {}
 
@@ -10235,13 +10269,17 @@ snapshots:
 
   date-fns@4.4.0: {}
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js-light@2.5.1: {}
 
@@ -10470,18 +10508,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.1.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.1
-      eslint: 9.39.2(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.7.0))
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       globals: 16.4.0
-      typescript-eslint: 8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      typescript-eslint: 8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10490,62 +10528,62 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
 
-  eslint-import-resolver-node@0.3.10:
+  eslint-import-resolver-node@0.3.10(supports-color@8.1.1):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.16.2
       resolve: 2.0.0-next.7
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.7.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-es@3.0.1(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-es@3.0.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10557,13 +10595,13 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -10573,7 +10611,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -10582,37 +10620,37 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-node@11.1.0(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-node@11.1.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.7.0)
-      eslint-plugin-es: 3.0.1(eslint@9.39.2(jiti@2.7.0))
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-plugin-es: 3.0.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       eslint-utils: 2.1.0
       ignore: 5.3.2
       minimatch: 3.1.5
       resolve: 1.22.12
       semver: 6.3.1
 
-  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))(prettier@3.7.4):
+  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.7.4):
     dependencies:
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       prettier: 3.7.4
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.2(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -10620,7 +10658,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.3
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
@@ -10634,11 +10672,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -10657,14 +10695,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.2(jiti@2.7.0):
+  eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@8.1.1)
       '@eslint/js': 9.39.2
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -10674,7 +10712,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -10822,9 +10860,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -10996,17 +11034,17 @@ snapshots:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11200,9 +11238,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@6.0.3:
+  istanbul-lib-instrument@6.0.3(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -11216,10 +11254,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -11250,10 +11288,10 @@ snapshots:
       jest-util: 30.4.1
       p-limit: 3.1.0
 
-  jest-circus@30.4.2:
+  jest-circus@30.4.2(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1
+      '@jest/expect': 30.4.1(supports-color@8.1.1)
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       '@types/node': 22.15.29
@@ -11264,8 +11302,8 @@ snapshots:
       jest-each: 30.4.1
       jest-matcher-utils: 30.4.1
       jest-message-util: 30.4.1
-      jest-runtime: 30.4.2
-      jest-snapshot: 30.4.1
+      jest-runtime: 30.4.2(supports-color@8.1.1)
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
       jest-util: 30.4.1
       p-limit: 3.1.0
       pretty-format: 30.4.1
@@ -11276,15 +11314,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@22.15.29):
+  jest-cli@30.4.2(@types/node@22.15.29)(supports-color@8.1.1):
     dependencies:
-      '@jest/core': 30.4.2
+      '@jest/core': 30.4.2(supports-color@8.1.1)
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@22.15.29)
+      jest-config: 30.4.2(@types/node@22.15.29)(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.3
@@ -11295,25 +11333,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@22.15.29):
+  jest-config@30.4.2(@types/node@22.15.29)(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.4.0
       '@jest/test-sequencer': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.7)
+      babel-jest: 30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.4.2
+      jest-circus: 30.4.2(supports-color@8.1.1)
       jest-docblock: 30.4.0
       jest-environment-node: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-runner: 30.4.2
+      jest-runner: 30.4.2(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       parse-json: 5.2.0
@@ -11345,11 +11383,11 @@ snapshots:
       jest-util: 30.4.1
       pretty-format: 30.4.1
 
-  jest-environment-jsdom@30.4.1:
+  jest-environment-jsdom@30.4.1(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/environment-jsdom-abstract': 30.4.1(jsdom@26.1.0)
-      jsdom: 26.1.0
+      '@jest/environment-jsdom-abstract': 30.4.1(jsdom@26.1.0(supports-color@8.1.1))
+      jsdom: 26.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11417,10 +11455,10 @@ snapshots:
 
   jest-regex-util@30.4.0: {}
 
-  jest-resolve-dependencies@30.4.2:
+  jest-resolve-dependencies@30.4.2(supports-color@8.1.1):
     dependencies:
       jest-regex-util: 30.4.0
-      jest-snapshot: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11435,12 +11473,12 @@ snapshots:
       slash: 3.0.0
       unrs-resolver: 1.12.2
 
-  jest-runner@30.4.2:
+  jest-runner@30.4.2(supports-color@8.1.1):
     dependencies:
       '@jest/console': 30.4.1
       '@jest/environment': 30.4.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@types/node': 22.15.29
       chalk: 4.1.2
@@ -11453,7 +11491,7 @@ snapshots:
       jest-leak-detector: 30.4.1
       jest-message-util: 30.4.1
       jest-resolve: 30.4.1
-      jest-runtime: 30.4.2
+      jest-runtime: 30.4.2(supports-color@8.1.1)
       jest-util: 30.4.1
       jest-watcher: 30.4.1
       jest-worker: 30.4.1
@@ -11462,14 +11500,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.4.2:
+  jest-runtime@30.4.2(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
-      '@jest/globals': 30.4.1
+      '@jest/globals': 30.4.1(supports-color@8.1.1)
       '@jest/source-map': 30.0.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
       '@types/node': 22.15.29
       chalk: 4.1.2
@@ -11482,26 +11520,26 @@ snapshots:
       jest-mock: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-snapshot: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@8.1.1)
       jest-util: 30.4.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@30.4.1:
+  jest-snapshot@30.4.1(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/generator': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/types': 7.29.7
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.4.1
-      '@jest/transform': 30.4.1
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@8.1.1))
       chalk: 4.1.2
       expect: 30.4.1
       graceful-fs: 4.2.11
@@ -11552,12 +11590,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@22.15.29):
+  jest@30.4.2(@types/node@22.15.29)(supports-color@8.1.1):
     dependencies:
-      '@jest/core': 30.4.2
+      '@jest/core': 30.4.2(supports-color@8.1.1)
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@22.15.29)
+      jest-cli: 30.4.2(@types/node@22.15.29)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11580,14 +11618,14 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.24
       parse5: 7.3.0
@@ -11828,16 +11866,16 @@ snapshots:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
-  mongodb-memory-server-core@11.2.0:
+  mongodb-memory-server-core@11.2.0(supports-color@8.1.1):
     dependencies:
       async-mutex: 0.5.0
       camelcase: 6.3.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       find-cache-dir: 3.3.2
-      follow-redirects: 1.16.0(debug@4.4.3)
-      https-proxy-agent: 7.0.6
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       mongodb: 7.5.0
-      new-find-package-json: 2.0.0
+      new-find-package-json: 2.0.0(supports-color@8.1.1)
       semver: 7.8.5
       tar-stream: 3.2.0
       tslib: 2.8.1
@@ -11855,9 +11893,9 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb-memory-server@11.2.0:
+  mongodb-memory-server@11.2.0(supports-color@8.1.1):
     dependencies:
-      mongodb-memory-server-core: 11.2.0
+      mongodb-memory-server-core: 11.2.0(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -11884,13 +11922,13 @@ snapshots:
       bson: 7.3.1
       mongodb-connection-string-url: 7.0.1
 
-  mongoose@8.24.1:
+  mongoose@8.24.1(supports-color@8.1.1):
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3
       mongodb: 6.20.0
       mpath: 0.9.0
-      mquery: 5.0.0
+      mquery: 5.0.0(supports-color@8.1.1)
       ms: 2.1.3
       sift: 17.1.3
     transitivePeerDependencies:
@@ -11911,9 +11949,9 @@ snapshots:
 
   mpath@0.9.0: {}
 
-  mquery@5.0.0:
+  mquery@5.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11927,9 +11965,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  new-find-package-json@2.0.0:
+  new-find-package-json@2.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11938,7 +11976,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@16.2.10(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.10(@babel/core@7.29.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -11947,7 +11985,7 @@ snapshots:
       postcss: 8.5.10
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.10
       '@next/swc-darwin-x64': 16.2.10
@@ -12649,12 +12687,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
   supports-color@7.2.0:
     dependencies:
@@ -12766,12 +12804,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@22.15.29))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7(supports-color@8.1.1))(@jest/transform@30.4.1(supports-color@8.1.1))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.15.29)(supports-color@8.1.1))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@22.15.29)
+      jest: 30.4.2(@types/node@22.15.29)(supports-color@8.1.1)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -12780,10 +12818,11 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.7
-      '@jest/transform': 30.4.1
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@jest/transform': 30.4.1(supports-color@8.1.1)
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.7)
+      babel-jest: 30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      esbuild: 0.28.1
       jest-util: 30.4.1
 
   tsconfig-paths@3.15.0:
@@ -12844,13 +12883,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12866,6 +12905,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
Closes #113.

## Summary
- Adds `lib/redis.ts` — `getRedisClient()` returns a memoized `@upstash/redis` client, or `null` when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are absent. Every consumer must handle `null`, so local dev and CI need no Redis. `REDIS_KEY_PREFIX` (`lodgeflow`) namespaces all keys.
- Backs `lib/rate-limit.ts` with `@upstash/ratelimit` when Upstash is configured, falling back to the existing module-level `Map` otherwise. Both modes use a fixed window, so their semantics are identical (verified below).
- Makes `checkRateLimit()` async (`Promise<RateLimitResult>`) and adds `await` at its three call sites: `app/api/send/confirm`, `app/api/send/welcome`, `app/api/customers` POST. The sync in-memory path stays reachable as `checkRateLimitInMemory()` for tests.
- Backs the Clerk user cache in `lib/clerk-users.ts` with Redis at the existing 5-minute TTL (`px: CACHE_DURATION`), falling back to the `Map` otherwise. `getClerkUser()` / `getClerkUsersBatch()` signatures are unchanged.
- Cached payloads are wrapped as `{ data: Customer | null }` so a cached "user deleted" (`null`) stays distinguishable from a cache miss — Redis returns `null` for an absent key either way. Only a genuine 404 is cached as `null`; transient 429/5xx are still never cached.
- `reviveCustomerDates()` rehydrates `created_at`, `updated_at`, `last_sign_in_at`, `last_active_at`, and `lastBookingDate` on every Redis read, since JSON has no `Date`.
- `getClerkUsersBatch()` reads the whole id set through one `mget` instead of N per-key lookups.
- Updates `CLAUDE.md`: **Rate Limiting** rewritten for dual-mode, new **Distributed State** subsection, expanded **Clerk Rate Limiting**, and the two `UPSTASH_REDIS_REST_*` vars added to the optional env block.

## Details

**Failure semantics.** Redis is never on the critical path for correctness:
- `checkRateLimit()` **fails open** on a Redis error — the request is allowed, `logger.error` records it. An Upstash outage degrades to "no rate limiting" rather than 429-ing every email send and customer create.
- Cache reads treat a Redis error as a miss and fall through to Clerk; cache writes and invalidations log and swallow (a failed write costs a future miss; a failed invalidation is bounded by the 5-minute TTL).

**Semantic equivalence between the two modes.** Verified against the real `@upstash/ratelimit@2.0.8` single-region fixed-window path rather than assumed:
- `success = usedTokensAfterUpdate <= effectiveLimit` allows exactly `limit` requests per window — same as the in-memory store, which blocks on `record.count >= config.limit` before incrementing.
- `remaining = max(0, effectiveLimit - usedTokensAfterUpdate)` — first request under `limit: 3` reports `remaining: 2` in both modes.
- `reset` is an absolute ms timestamp, which is what `createRateLimitResponse()` expects for `Retry-After` / `X-RateLimit-Reset`.
- `Ratelimit.fixedWindow(limit, `${windowMs} ms`)` — `ms()` parses via `/^(\d+)\s?(ms|s|m|h|d)$/`, so `"60000 ms"` is 60000. Confirmed end-to-end against a recording fake `Redis`: the library issues `EVAL` with key `lodgeflow:ratelimit:user_abc:send-confirm:<bucket>` and args `[5, 60000, 1]`.

`Ratelimit` instances are cached per `limit:windowMs` so the Lua scripts aren't rebuilt per request.

## Why

The issue's acceptance criteria asked for unchanged signatures with callers unmodified, but any Redis call is async and `checkRateLimit()` was sync — the two can't both hold. Making it async was chosen over adding a parallel `checkRateLimitDistributed()`, since the latter leaves every existing route on the per-instance limiter and doesn't actually fix the bug. All three call sites were already inside `async` route handlers, so each needed only an added `await`.

Fail-open was chosen over fail-closed so an Upstash outage doesn't take down email sending and customer creation.

## Notes

The issue's `## Problem` section describes files that don't exist in this repo — there is no `lib/actions/` directory, the function is `checkRateLimit()` not `rateLimit()`, the callers are API routes, and `getClerkUser()` caches `Customer | null` (not Clerk's `User`) against a `CACHE_DURATION` constant (not `CACHE_TTL`). The substance of the issue is accurate and this PR implements it against the real code.

The 100 ms `MIN_REQUEST_INTERVAL` throttle in `waitForRateLimit()` is deliberately left per-instance. The issue's `## Scope` only calls for the user cache to move to Redis, and the throttle paces this process's own Clerk calls — moving it to Redis would add a round trip per Clerk request.

Both new test files live in the `unit` project rather than `integration`: neither the rate limiter nor the user cache touches MongoDB, so the Memory Server adds nothing.

## Test plan
- [x] `pnpm ci:check` — format clean, lint 0 errors, **943 passing / 54 suites** across all three projects (up from 916 / 52 at base)
- [x] `pnpm check:types` — clean
- [x] `npx jest --selectProjects unit --testPathPatterns rate-limit` — 16/16 pass: in-memory fallback (limit, block, per-identifier isolation, window rollover, `MUTATION` default, no Upstash construction), distributed store selection (routes through `@upstash/ratelimit`, `fixedWindow(5, '60000 ms')`, `lodgeflow:ratelimit` prefix, limiter reuse per config, denial propagation), and fail-open on both a single and repeated Redis errors
- [x] `npx jest --selectProjects unit --testPathPatterns clerk-users` — 41/41 pass across the 3 clerk suites, including the 15 new Redis-cache cases: hit without a Clerk call, `Date` revival, `null` `last_sign_in_at` preserved, write-through with `px: 300000`, cached-`null`-vs-miss, 404 cached / 500 not cached, read-failure and write-failure tolerance, `mget` single round trip, partial batch hits, and the in-memory fallback still short-circuiting Redis entirely
- [x] Real-library check (throwaway script, not committed): constructed the actual `Ratelimit` against a recording fake `Redis` and confirmed the emitted key and `[tokens, window, incrementBy]` args
- [ ] Distributed path against a live Upstash instance — not run; no Upstash project is provisioned. Every test above exercises the Redis branch through a mocked client.

## Follow-up
- Provision Upstash Redis (Vercel Marketplace) and set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in the Vercel project. **Until both are set, production keeps the per-instance behavior this PR exists to fix** — the code ships safe but inert.

## Out of scope (deferred)
- Redis-backed session storage or other cross-instance state beyond rate limiting and the user cache.
- Custom rate-limit dashboards or monitoring (Upstash's own dashboard covers it).
- Migrating `/api/cron/seed` to the shared cache.
- Wiring the `BOOKING_CREATE` preset into `app/api/bookings`, which remains unused as noted in `CLAUDE.md`.
