### PR TITLE
Derive depositAmount from settings on create, freeze it on update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,20 @@ from the `Cabin` and `Settings` documents — never from the request body. It th
 - The Zod schemas in `lib/validations/booking.ts` still type these fields for compatibility, but
   they are always ignored/recomputed at the route layer — don't rely on client-submitted values.
 
+**`depositAmount` is derived on create and frozen on update** (issue #124). It is never
+read from the request body on either route:
+
+- `POST /api/bookings` sets it from `calculateDepositAmount({ settings, totalPrice })`
+  (`lib/booking-pricing.ts`) — `settings.requireDeposit ? round(totalPrice * depositPercentage / 100) : 0`,
+  clamped to `[0, totalPrice]` — and sets `remainingAmount` to `totalPrice - depositAmount`.
+- `PUT /api/bookings` deletes it outright and never recomputes it. On an existing booking
+  `depositAmount` doubles as the running total of payments actually taken, so recomputing it
+  would wipe a real deposit when an admin edits an unrelated field. `remainingAmount` is
+  recomputed as `max(0, newTotalPrice - existingBooking.depositAmount)` when the total moves.
+- The only writer is `PATCH /api/bookings/[id]`'s `recordPayment` handler, which accumulates
+  `depositAmount` from the `amountPaid` it was given. Any new deposit-adjusting flow must go
+  through that path, not `PUT`.
+
 ### Clerk Rate Limiting
 API has concurrent call limits. Clerk user batch fetching uses `CLERK_API_CONCURRENT_LIMIT` env var (defaults to 3) in `lib/clerk-users.ts`.
 

--- a/__tests__/integration/api/bookings.test.ts
+++ b/__tests__/integration/api/bookings.test.ts
@@ -319,6 +319,58 @@ describe('Bookings API Routes', () => {
       expect(body.data.totalPrice).toBe(800);
     });
 
+    it('ignores a client-supplied depositAmount and derives it from settings', async () => {
+      const cabin = await createTestCabin({ price: 200, discount: 0 });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-08-01',
+          checkOutDate: '2027-08-05', // 4 nights → totalPrice 800
+          numGuests: 2,
+          // Claiming a deposit equal to the total would drive remainingAmount
+          // to 0 and make the booking read as fully paid (issue #124).
+          depositAmount: 800,
+          remainingAmount: 0,
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.data.totalPrice).toBe(800);
+      // Default seeded settings: requireDeposit true, depositPercentage 25.
+      expect(body.data.depositAmount).toBe(200);
+      expect(body.data.remainingAmount).toBe(600); // 800 - 200, not the claimed 0
+    });
+
+    it('sets depositAmount to 0 when settings do not require a deposit', async () => {
+      await Settings.create({ ...settingsData, requireDeposit: false });
+      const cabin = await createTestCabin({ price: 200, discount: 0 });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'POST',
+        body: {
+          cabin: cabin._id.toString(),
+          customer: 'user_test123',
+          checkInDate: '2027-08-01',
+          checkOutDate: '2027-08-05',
+          numGuests: 2,
+          depositAmount: 800, // tampered — should be ignored
+        },
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.data.depositAmount).toBe(0);
+      expect(body.data.remainingAmount).toBe(800);
+    });
+
     it('applies the cabin discount when computing cabinPrice', async () => {
       const cabin = await createTestCabin({ price: 200, discount: 50 });
 
@@ -843,18 +895,20 @@ describe('Bookings API Routes', () => {
       expect(body.data.totalPrice).toBe(1050); // 350 * 3 nights
     });
 
-    it('recomputes remainingAmount from the existing totalPrice when only depositAmount changes', async () => {
+    it('ignores a client-supplied depositAmount and leaves the recorded deposit untouched', async () => {
       const cabin = await createTestCabin();
       const booking = await createTestBooking(cabin._id, {
         totalPrice: 600,
-        depositAmount: 0,
+        depositAmount: 200, // a real deposit taken via PATCH recordPayment
       });
 
       const request = createRequest('http://localhost:3000/api/bookings', {
         method: 'PUT',
         body: {
           _id: booking._id.toString(),
-          depositAmount: 300,
+          // Claiming a deposit equal to the total would zero out
+          // remainingAmount with no payment recorded (issue #124).
+          depositAmount: 600,
         },
       });
 
@@ -862,9 +916,43 @@ describe('Bookings API Routes', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      // totalPrice must be untouched — only depositAmount changed
       expect(body.data.totalPrice).toBe(600);
-      expect(body.data.remainingAmount).toBe(300); // 600 - 300
+      expect(body.data.depositAmount).toBe(200); // not the tampered 600
+      expect(body.data.remainingAmount).toBe(400); // 600 - 200, not 0
+    });
+
+    it('preserves a recorded deposit and recomputes remainingAmount when an unrelated field changes', async () => {
+      const cabin = await createTestCabin({
+        price: 200,
+        capacity: 4,
+        extraGuestFee: 20,
+      });
+      const booking = await createTestBooking(cabin._id, {
+        numGuests: 1,
+        cabinPrice: 200,
+        extrasPrice: 0,
+        totalPrice: 600, // 200 * 3 nights
+        depositAmount: 200,
+      });
+
+      const request = createRequest('http://localhost:3000/api/bookings', {
+        method: 'PUT',
+        body: {
+          _id: booking._id.toString(),
+          numGuests: 3,
+        },
+      });
+
+      const response = await PUT(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      // extraGuestFee: (3 - 1) * 20 * 3 nights = 120
+      expect(body.data.totalPrice).toBe(720);
+      // The deposit must survive a pricing recompute triggered by an
+      // unrelated edit — it reflects money actually taken.
+      expect(body.data.depositAmount).toBe(200);
+      expect(body.data.remainingAmount).toBe(520); // 720 - 200
     });
 
     it('returns a 400 (not a 500) when only checkOutDate changes to the same calendar day as the existing checkInDate', async () => {

--- a/__tests__/unit/lib/booking-pricing.test.ts
+++ b/__tests__/unit/lib/booking-pricing.test.ts
@@ -1,6 +1,7 @@
 import {
   BookingPricingError,
   calculateBookingPricing,
+  calculateDepositAmount,
 } from '@/lib/booking-pricing';
 
 const baseCabin = { price: 200, discount: 0, extraGuestFee: 0 };
@@ -280,5 +281,63 @@ describe('calculateBookingPricing', () => {
     });
 
     expect(result.extras.breakfastPrice).toBe(15 * 2 * 4);
+  });
+});
+
+describe('calculateDepositAmount', () => {
+  it('takes the configured percentage of the total price', () => {
+    expect(
+      calculateDepositAmount({
+        settings: { requireDeposit: true, depositPercentage: 25 },
+        totalPrice: 800,
+      })
+    ).toBe(200);
+  });
+
+  it('rounds to the nearest whole unit', () => {
+    expect(
+      calculateDepositAmount({
+        settings: { requireDeposit: true, depositPercentage: 25 },
+        totalPrice: 610,
+      })
+    ).toBe(153); // 152.5 rounded
+  });
+
+  it('returns 0 when deposits are not required', () => {
+    expect(
+      calculateDepositAmount({
+        settings: { requireDeposit: false, depositPercentage: 25 },
+        totalPrice: 800,
+      })
+    ).toBe(0);
+  });
+
+  it('returns 0 for a zero percentage', () => {
+    expect(
+      calculateDepositAmount({
+        settings: { requireDeposit: true, depositPercentage: 0 },
+        totalPrice: 800,
+      })
+    ).toBe(0);
+  });
+
+  it('never exceeds the total price', () => {
+    // depositPercentage is schema-bound to 0-100, but a legacy or hand-edited
+    // settings document must not be able to drive remainingAmount negative.
+    expect(
+      calculateDepositAmount({
+        settings: { requireDeposit: true, depositPercentage: 150 },
+        totalPrice: 800,
+      })
+    ).toBe(800);
+  });
+
+  it('never returns a negative deposit', () => {
+    expect(
+      calculateDepositAmount({
+        settings: { requireDeposit: true, depositPercentage: -25 },
+        totalPrice: 800,
+      })
+    ).toBe(0);
   });
 });

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -8,6 +8,7 @@ import mongoose from 'mongoose';
 import {
   BookingPricingError,
   calculateBookingPricing,
+  calculateDepositAmount,
 } from '@/lib/booking-pricing';
 import {
   CabinBookingLockTimeoutError,
@@ -261,6 +262,14 @@ export async function POST(request: NextRequest) {
       numGuests,
       extras,
     });
+    // The deposit is likewise derived from settings, never from the request
+    // body — a client-supplied depositAmount equal to totalPrice would drive
+    // remainingAmount to 0 and make the booking read as fully paid (#124).
+    const depositAmount = calculateDepositAmount({
+      settings,
+      totalPrice: pricing.totalPrice,
+    });
+
     const { numNights } = pricing;
     const effectiveMinNights = Math.max(
       settings.minBookingLength,
@@ -326,6 +335,8 @@ export async function POST(request: NextRequest) {
           extrasPrice: pricing.extrasPrice,
           totalPrice: pricing.totalPrice,
           extras: pricing.extras,
+          depositAmount,
+          remainingAmount: Math.max(0, pricing.totalPrice - depositAmount),
         });
         return { ok: true, booking: created };
       }
@@ -467,6 +478,13 @@ export async function PUT(request: NextRequest) {
     delete updateData.extrasPrice;
     delete updateData.totalPrice;
     delete updateData.remainingAmount;
+    // depositAmount is frozen here rather than recomputed (see issue #124).
+    // On an existing booking it doubles as the running total of payments
+    // actually taken — PATCH /api/bookings/[id]'s recordPayment handler is
+    // its only writer — so honoring a client value would let a raw request
+    // mark a booking paid, while recomputing it from settings would wipe a
+    // real deposit whenever an unrelated field changed.
+    delete updateData.depositAmount;
 
     // Fetch the existing booking first so auto-timestamping can check prior state
     const existingBooking = await Booking.findById(_id);
@@ -679,17 +697,12 @@ export async function PUT(request: NextRequest) {
     // numGuests, or extras change — findByIdAndUpdate bypasses the Mongoose
     // pre-save hook that would otherwise handle this.
 
-    if (
-      updateData.totalPrice !== undefined ||
-      updateData.depositAmount !== undefined
-    ) {
-      const effectiveTotalPrice =
-        updateData.totalPrice ?? existingBooking.totalPrice;
-      const effectiveDepositAmount =
-        updateData.depositAmount ?? existingBooking.depositAmount;
+    // Only totalPrice can move here — the deposit already on the booking is
+    // carried over untouched so a recorded payment survives the edit.
+    if (updateData.totalPrice !== undefined) {
       updateData.remainingAmount = Math.max(
         0,
-        effectiveTotalPrice - effectiveDepositAmount
+        updateData.totalPrice - (existingBooking.depositAmount ?? 0)
       );
     }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,6 +212,10 @@ POST /api/bookings
 
 Creates a new booking. Validates for date conflicts with existing bookings.
 
+Every price-derived field is computed server-side from the `Cabin` and
+`Settings` documents and any client-supplied value is discarded — see
+`lib/booking-pricing.ts`.
+
 **Request Body:**
 
 | Field | Type | Required | Description |
@@ -222,13 +226,15 @@ Creates a new booking. Validates for date conflicts with existing bookings.
 | `checkOutDate` | string (ISO) | Yes | Check-out date |
 | `numGuests` | number | Yes | Number of guests (1-50, capped by cabin capacity and settings) |
 | `status` | string | No | Default: `unconfirmed` |
-| `cabinPrice` | number | No | Price per night |
-| `extrasPrice` | number | No | Default: `0` |
-| `totalPrice` | number | No | Total booking price |
+| `numNights` | number | No | **Ignored** — derived from the dates |
+| `cabinPrice` | number | No | **Ignored** — derived from the cabin document |
+| `extrasPrice` | number | No | **Ignored** — derived from cabin/settings |
+| `totalPrice` | number | No | **Ignored** — derived from cabin/settings |
 | `isPaid` | boolean | No | Default: `false` |
 | `paymentMethod` | string | No | `cash`, `card`, `bank-transfer`, `online` |
 | `depositPaid` | boolean | No | Default: `false` |
-| `depositAmount` | number | No | Default: `0` |
+| `depositAmount` | number | No | **Ignored** — derived from `settings.requireDeposit`/`depositPercentage` |
+| `remainingAmount` | number | No | **Ignored** — `totalPrice - depositAmount` |
 | `stripePaymentIntentId` | string | No | Stripe payment intent ID (must start with `pi_`) |
 | `stripeSessionId` | string | No | Stripe session ID (must start with `cs_`) |
 | `paidAt` | string (ISO) | No | Payment timestamp |
@@ -335,11 +341,19 @@ PUT /api/bookings
 
 Updates an existing booking. Validates for date conflicts.
 
+`numNights`, `cabinPrice`, `extrasPrice`, `totalPrice`, and `remainingAmount`
+are ignored if sent: they are recomputed from the `Cabin`/`Settings` documents
+whenever a pricing-relevant field (`cabin`, `checkInDate`, `checkOutDate`,
+`numGuests`, `extras`) changes. `depositAmount` is ignored too, but is *not*
+recomputed — it tracks money actually taken, so it carries over untouched and
+can only be changed through `PATCH /api/bookings/[id]`'s `recordPayment`.
+
 **Request Body:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `_id` | string | Yes | Booking ObjectId |
+| `depositAmount` | number | No | **Ignored** — use `PATCH /api/bookings/[id]` `recordPayment` |
 | (other fields) | various | No | Fields to update |
 
 **Response:**

--- a/lib/booking-pricing.ts
+++ b/lib/booking-pricing.ts
@@ -39,6 +39,16 @@ export interface BookingPricingExtrasSelection {
   hasLateCheckOut?: boolean;
 }
 
+export interface BookingDepositSettings {
+  requireDeposit: boolean;
+  depositPercentage: number;
+}
+
+export interface BookingDepositInput {
+  settings: BookingDepositSettings;
+  totalPrice: number;
+}
+
 export interface BookingPricingInput {
   cabin: BookingPricingCabin;
   settings: BookingPricingSettings;
@@ -65,6 +75,30 @@ export interface BookingPricingResult {
     hasLateCheckOut: boolean;
     lateCheckOutFee: number;
   };
+}
+
+/**
+ * Derives the deposit due on a *new* booking from the settings document,
+ * never from client input (see issue #124 — a client-supplied depositAmount
+ * equal to totalPrice would make a booking read as fully paid with no payment
+ * recorded).
+ *
+ * Deliberately not applied on update: on an existing booking `depositAmount`
+ * doubles as the running total of payments actually taken (see the
+ * `recordPayment` handler in `app/api/bookings/[id]/route.ts`), so recomputing
+ * it would wipe a real deposit whenever an unrelated field changed.
+ */
+export function calculateDepositAmount({
+  settings,
+  totalPrice,
+}: BookingDepositInput): number {
+  if (!settings.requireDeposit) return 0;
+
+  const deposit = Math.round(totalPrice * (settings.depositPercentage / 100));
+  // depositPercentage is schema-bound to 0-100, but clamp anyway so a legacy
+  // or hand-edited settings document can never yield a deposit that exceeds
+  // the total (which would drive remainingAmount negative).
+  return Math.min(Math.max(deposit, 0), totalPrice);
 }
 
 /**

--- a/lib/validations/booking.ts
+++ b/lib/validations/booking.ts
@@ -58,6 +58,10 @@ export const createBookingSchema = z
     isPaid: z.boolean().optional().default(false),
     paymentMethod: paymentMethodSchema.optional(),
     depositPaid: z.boolean().optional().default(false),
+    // depositAmount is accepted for schema shape only — the API route derives
+    // it from settings.requireDeposit/depositPercentage and the server-computed
+    // totalPrice (see calculateDepositAmount in lib/booking-pricing.ts and
+    // issue #124). Any client-supplied value is ignored on create.
     depositAmount: z.number().min(0).optional().default(0),
     stripePaymentIntentId: z.string().startsWith('pi_').max(255).optional(),
     stripeSessionId: z.string().startsWith('cs_').max(255).optional(),
@@ -84,14 +88,16 @@ export const updateBookingSchema = z
     checkInDate: z.coerce.date().optional(),
     checkOutDate: z.coerce.date().optional(),
     numGuests: z.number().int().min(1).max(50).optional(),
-    // numNights, cabinPrice, extrasPrice, totalPrice, and remainingAmount
-    // (below) are accepted here for schema shape only — the API route
-    // recomputes numNights/cabinPrice/extrasPrice/totalPrice server-side from
-    // the cabin and settings documents whenever a pricing-relevant field
-    // (cabin, dates, numGuests, extras) changes, and remainingAmount from
-    // totalPrice/depositAmount whenever either changes. Client-supplied
-    // values for all of these are ignored outright (see
-    // calculateBookingPricing in lib/booking-pricing.ts and issue #122).
+    // numNights, cabinPrice, extrasPrice, totalPrice, depositAmount, and
+    // remainingAmount (below) are accepted here for schema shape only — the
+    // API route recomputes numNights/cabinPrice/extrasPrice/totalPrice
+    // server-side from the cabin and settings documents whenever a
+    // pricing-relevant field (cabin, dates, numGuests, extras) changes, and
+    // remainingAmount from the new totalPrice and the deposit already stored
+    // on the booking. depositAmount itself is never writable through this
+    // route — PATCH /api/bookings/[id]'s recordPayment is its only writer.
+    // Client-supplied values for all of these are ignored outright (see
+    // calculateBookingPricing in lib/booking-pricing.ts and issues #122/#124).
     numNights: z.number().int().min(1).optional(),
     status: bookingStatusSchema.optional(),
     cabinPrice: z.number().min(0).optional(),


### PR DESCRIPTION
Closes #124 · Follows #123 (`PUT /api/bookings` pricing lockdown), which deliberately deferred `depositAmount`.

## Summary
- Adds `calculateDepositAmount({ settings, totalPrice })` to `lib/booking-pricing.ts` — `settings.requireDeposit ? round(totalPrice * depositPercentage / 100) : 0`, clamped to `[0, totalPrice]` so a legacy or hand-edited settings document can't drive `remainingAmount` negative.
- `POST /api/bookings` now derives `depositAmount` from that helper and the server-computed `totalPrice`, and writes `remainingAmount` explicitly instead of relying on the `Booking` pre-save hook. Any client-supplied `depositAmount` is discarded.
- `PUT /api/bookings` deletes `depositAmount` from the update payload alongside the other server-owned pricing fields, and never recomputes it. `remainingAmount` is now recomputed only when `totalPrice` moves, from the new total and the deposit already stored on the booking.
- Invariant: `PATCH /api/bookings/[id]`'s `recordPayment` handler is the single writer of `depositAmount` on an existing booking. Unchanged by this PR.
- Documents the rule in `CLAUDE.md` (Booking Pricing section) and `docs/api.md` (create/update request tables now mark every server-owned field as ignored).

## Why
The issue offered three approaches. This is approach 2 — derive on create, freeze on update.

Recomputing `depositAmount` on `PUT` (approach 1, a mechanical copy of the `totalPrice` fix from #123) would satisfy the security requirement but violate acceptance criterion 3: `depositAmount` doubles as the running total of payments actually taken (`app/api/bookings/[id]/route.ts` sets `booking.depositAmount = totalPaid`), so recomputing it from `settings.depositPercentage` would silently wipe a real customer payment the moment an admin edited `numGuests` or `status`. Freezing it satisfies that criterion by construction.

No admin UI regression: `hooks/useBookingForm.ts:198` already computes the deposit with exactly the formula now used server-side, and `components/BookingForm/PaymentInformation.tsx` exposes only a `depositPaid` switch — there is no deposit-amount input to break. The field is ignored silently rather than rejected with a 400 for the same reason `totalPrice` is: the form sends it on every `PUT`.

## Test plan
- [x] `pnpm ci:check` — format clean, lint clean, `52 suites / 921 tests` passing
- [x] `pnpm check:types` — clean
- [x] `pnpm test:unit` — 6 new `calculateDepositAmount` cases (percentage, rounding, `requireDeposit: false`, 0%, over-100% clamp, negative clamp)
- [x] `pnpm test:integration -- bookings` — 75 passing, including 4 new/rewritten cases:
  - POST: `depositAmount: 800` on an 800 total is ignored; stored deposit is 200 (25% of settings) and `remainingAmount` 600, not the claimed 0
  - POST: `depositAmount` forced to 0 when `settings.requireDeposit` is false
  - PUT: `depositAmount: 600` on a booking with a recorded 200 deposit is ignored; `remainingAmount` stays 400, not 0
  - PUT: changing `numGuests` recomputes `totalPrice` 600 → 720 while the recorded 200 deposit survives, `remainingAmount` 520

## Notes
- The rewritten PUT test replaces `recomputes remainingAmount from the existing totalPrice when only depositAmount changes`, which asserted the old (now-closed) behavior of honoring a client-supplied deposit.
- Branched off `main`, not the in-flight `feat/113-distributed-rate-limit-and-user-cache` branch — the two changes are independent.

## Out of scope
- `depositPaid` remains a client-writable boolean on `PUT`. It's display-only metadata (`components/BookingDetails/PaymentSummaryCard.tsx`, the `paymentStatus` virtual) and feeds no money arithmetic.
- On create, the deposit is derived whether or not `depositPaid` is set — unchanged from current behavior and from `scripts/seed.ts`. Whether an unpaid deposit should count against `remainingAmount` at all is a separate semantics question, not this trust boundary.