### PR TITLE
Encapsulate the CabinBookingLock protocol behind acquire/release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,19 @@ const result = await withCabinBookingLock(cabinId, async () => {
 });
 ```
 
+**This is structurally enforced, not just convention** (issue #126).
+`models/CabinBookingLock.ts` keeps its Mongoose model module-private and
+exports only two protocol methods — `acquire(cabin, token, ttlMs)` and
+`release(cabin, token)` — so raw `.create()` / `.deleteOne()` /
+`.findOneAndUpdate()` on the lock collection is unreachable at the type
+level from outside that module. The lock is also **deliberately absent
+from the `models/index.ts` barrel**: it's mutex infrastructure, not a
+domain model, and re-exporting it there would put raw lock CRUD one
+autocomplete away from every route. `withCabinBookingLock()` owns the
+retry budget, TTL, and `CabinBookingLockTimeoutError`; the model owns the
+fencing-token contract. Don't add a raw-model export or a barrel entry to
+work around this — extend the protocol methods instead.
+
 Settings is the single source of truth for booking business rules (min/max nights, deposit %, etc.). Booking API validation reads from the Settings document at request time.
 
 ### Booking Pricing Is Always Server-Computed

--- a/__tests__/integration/lib/cabin-booking-lock.test.ts
+++ b/__tests__/integration/lib/cabin-booking-lock.test.ts
@@ -4,7 +4,17 @@ import {
   CabinBookingLockTimeoutError,
   withCabinBookingLock,
 } from '@/lib/cabin-booking-lock';
-import CabinBookingLock from '@/models/CabinBookingLock';
+import CabinBookingLock, {
+  type ICabinBookingLock,
+} from '@/models/CabinBookingLock';
+
+// `models/CabinBookingLock.ts` keeps its Mongoose model private so no
+// caller can bypass the acquire/release protocol (issue #126). These
+// tests need to plant and inspect raw lock documents, so they reach the
+// model through Mongoose's registry — a deliberate, visible escape hatch
+// that production code has no reason to reproduce.
+const CabinBookingLockModel =
+  mongoose.model<ICabinBookingLock>('CabinBookingLock');
 
 describe('withCabinBookingLock', () => {
   const cabinId = new mongoose.Types.ObjectId();
@@ -16,7 +26,7 @@ describe('withCabinBookingLock', () => {
 
   it('releases the lock after the callback resolves', async () => {
     await withCabinBookingLock(cabinId, async () => 'done');
-    const remaining = await CabinBookingLock.findOne({ cabin: cabinId });
+    const remaining = await CabinBookingLockModel.findOne({ cabin: cabinId });
     expect(remaining).toBeNull();
   });
 
@@ -27,7 +37,7 @@ describe('withCabinBookingLock', () => {
       })
     ).rejects.toThrow('boom');
 
-    const remaining = await CabinBookingLock.findOne({ cabin: cabinId });
+    const remaining = await CabinBookingLockModel.findOne({ cabin: cabinId });
     expect(remaining).toBeNull();
   });
 
@@ -55,7 +65,7 @@ describe('withCabinBookingLock', () => {
   it('reclaims a stale (expired) lock instead of waiting out the full TTL', async () => {
     // Simulate a crashed holder: a lock doc whose expiresAt is already
     // in the past.
-    await CabinBookingLock.create({
+    await CabinBookingLockModel.create({
       cabin: cabinId,
       token: 'stale-token',
       expiresAt: new Date(Date.now() - 1000),
@@ -96,7 +106,7 @@ describe('withCabinBookingLock', () => {
   });
 
   it('lets only one of two concurrent reclaimers win the same stale lock', async () => {
-    await CabinBookingLock.create({
+    await CabinBookingLockModel.create({
       cabin: cabinId,
       token: 'stale-token',
       expiresAt: new Date(Date.now() - 1000),
@@ -124,7 +134,7 @@ describe('withCabinBookingLock', () => {
 
   it('does not mask a successful result when releasing the lock fails', async () => {
     const releaseSpy = jest
-      .spyOn(CabinBookingLock, 'deleteOne')
+      .spyOn(CabinBookingLock, 'release')
       .mockRejectedValueOnce(new Error('transient release failure'));
 
     const result = await withCabinBookingLock(cabinId, async () => 'done');
@@ -135,7 +145,7 @@ describe('withCabinBookingLock', () => {
 
   it('does not mask the original error when releasing the lock also fails', async () => {
     const releaseSpy = jest
-      .spyOn(CabinBookingLock, 'deleteOne')
+      .spyOn(CabinBookingLock, 'release')
       .mockRejectedValueOnce(new Error('transient release failure'));
 
     await expect(
@@ -156,13 +166,11 @@ describe('withCabinBookingLock', () => {
 
   it('gives up and throws CabinBookingLockTimeoutError once the acquire budget is exhausted', async () => {
     jest.useFakeTimers({ advanceTimers: true });
-    const permanentCollision = Object.assign(
-      new Error('E11000 duplicate key error'),
-      { code: 11000 }
-    );
+    // A permanently contended lock: every acquire attempt loses the race
+    // to a live holder, so the retry budget drains without success.
     const acquireSpy = jest
-      .spyOn(CabinBookingLock, 'findOneAndUpdate')
-      .mockRejectedValue(permanentCollision);
+      .spyOn(CabinBookingLock, 'acquire')
+      .mockResolvedValue(false);
 
     const assertion = expect(
       withCabinBookingLock(cabinId, async () => 'unreachable')
@@ -174,5 +182,92 @@ describe('withCabinBookingLock', () => {
 
     acquireSpy.mockRestore();
     jest.useRealTimers();
+  });
+});
+
+describe('CabinBookingLock protocol', () => {
+  const cabinId = new mongoose.Types.ObjectId();
+
+  // The unique index on `cabin` is what turns a contended acquire into an
+  // E11000 collision, so wait for it to finish building before racing it.
+  beforeAll(async () => {
+    await CabinBookingLockModel.init();
+  });
+
+  it('exposes only acquire and release, never raw Mongoose CRUD', () => {
+    expect(Object.keys(CabinBookingLock).sort()).toEqual([
+      'acquire',
+      'release',
+    ]);
+  });
+
+  it('acquires a free lock and stamps it with the caller token and TTL', async () => {
+    const before = Date.now();
+    await expect(
+      CabinBookingLock.acquire(cabinId, 'token-a', 10_000)
+    ).resolves.toBe(true);
+
+    const doc = await CabinBookingLockModel.findOne({ cabin: cabinId });
+    expect(doc?.token).toBe('token-a');
+    expect(doc?.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 10_000);
+  });
+
+  it('refuses to acquire a lock a live holder still owns', async () => {
+    await CabinBookingLock.acquire(cabinId, 'token-a', 10_000);
+
+    await expect(
+      CabinBookingLock.acquire(cabinId, 'token-b', 10_000)
+    ).resolves.toBe(false);
+
+    // The loser must not have disturbed the holder's stamp.
+    const doc = await CabinBookingLockModel.findOne({ cabin: cabinId });
+    expect(doc?.token).toBe('token-a');
+  });
+
+  it('reclaims an expired lock in place', async () => {
+    await CabinBookingLockModel.create({
+      cabin: cabinId,
+      token: 'crashed-holder',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    await expect(
+      CabinBookingLock.acquire(cabinId, 'token-b', 10_000)
+    ).resolves.toBe(true);
+
+    const doc = await CabinBookingLockModel.findOne({ cabin: cabinId });
+    expect(doc?.token).toBe('token-b');
+    expect(doc?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('releases a lock the caller still holds', async () => {
+    await CabinBookingLock.acquire(cabinId, 'token-a', 10_000);
+    await CabinBookingLock.release(cabinId, 'token-a');
+
+    expect(await CabinBookingLockModel.findOne({ cabin: cabinId })).toBeNull();
+  });
+
+  it('ignores a release from a holder whose lock was already reclaimed', async () => {
+    // The fencing token: an overran holder's late release must not free
+    // the lock its successor now legitimately owns.
+    await CabinBookingLock.acquire(cabinId, 'new-holder', 10_000);
+
+    await CabinBookingLock.release(cabinId, 'overran-holder');
+
+    const doc = await CabinBookingLockModel.findOne({ cabin: cabinId });
+    expect(doc?.token).toBe('new-holder');
+  });
+
+  it('rethrows acquire failures that are not lock contention', async () => {
+    const failure = Object.assign(new Error('connection reset'), { code: 6 });
+    const spy = jest
+      .spyOn(CabinBookingLockModel, 'findOneAndUpdate')
+      .mockRejectedValueOnce(failure);
+
+    await expect(
+      CabinBookingLock.acquire(cabinId, 'token-a', 10_000)
+    ).rejects.toThrow('connection reset');
+
+    spy.mockRestore();
   });
 });

--- a/lib/cabin-booking-lock.ts
+++ b/lib/cabin-booking-lock.ts
@@ -32,15 +32,6 @@ export class CabinBookingLockTimeoutError extends Error {
 /** Discriminated result of a locked write that may be rejected by an overlap check. */
 export type LockedWriteResult<T> = { ok: true; booking: T } | { ok: false };
 
-function isDuplicateKeyError(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error as { code?: number }).code === 11000
-  );
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -53,6 +44,14 @@ function sleep(ms: number): Promise<void> {
  * `CabinBookingLock.cabin`, not a MongoDB transaction — two transactions
  * each inserting a *different* document don't conflict under MongoDB's
  * transaction semantics, so a transaction alone wouldn't close this race.
+ *
+ * This is the only supported way to hold the lock. `CabinBookingLock`
+ * keeps its Mongoose model private and exposes just `acquire`/`release`
+ * (issue #126), so the worst a caller reaching past this function can do
+ * is hold a well-formed lock until its TTL expires — raw CRUD that could
+ * delete a live holder's lock or write a bogus `expiresAt` is
+ * unreachable. Prefer this wrapper: it also owns the retry budget and
+ * the guaranteed release.
  */
 export async function withCabinBookingLock<T>(
   cabinId: mongoose.Types.ObjectId | string,
@@ -63,25 +62,14 @@ export async function withCabinBookingLock<T>(
   let acquired = false;
 
   for (let attempt = 0; attempt < ACQUIRE_MAX_ATTEMPTS; attempt++) {
-    const now = new Date();
-    try {
-      // If no lock exists yet for this cabin, or the existing one has
-      // expired, this filter matches and the upsert succeeds (as an
-      // insert or an in-place update, respectively). If an active,
-      // non-expired lock already exists, the filter matches nothing, so
-      // Mongo attempts an upsert *insert* instead — which collides with
-      // the unique index on `cabin` and throws E11000.
-      await CabinBookingLock.findOneAndUpdate(
-        { cabin: cabinObjectId, expiresAt: { $lt: now } },
-        { $set: { token, expiresAt: new Date(now.getTime() + LOCK_TTL_MS) } },
-        { upsert: true, runValidators: true }
-      );
+    // Takes the lock outright when it's free or already expired; returns
+    // false while a live holder still owns it, which is the signal to
+    // back off and retry rather than an error.
+    if (await CabinBookingLock.acquire(cabinObjectId, token, LOCK_TTL_MS)) {
       acquired = true;
       break;
-    } catch (error) {
-      if (!isDuplicateKeyError(error)) throw error;
-      await sleep(ACQUIRE_RETRY_DELAY_MS);
     }
+    await sleep(ACQUIRE_RETRY_DELAY_MS);
   }
 
   if (!acquired) {
@@ -101,7 +89,7 @@ export async function withCabinBookingLock<T>(
   }
 
   try {
-    await CabinBookingLock.deleteOne({ cabin: cabinObjectId, token });
+    await CabinBookingLock.release(cabinObjectId, token);
   } catch (releaseError) {
     logger.warn(
       'Failed to release cabin booking lock (will self-heal via TTL)',

--- a/models/CabinBookingLock.ts
+++ b/models/CabinBookingLock.ts
@@ -1,5 +1,10 @@
 import mongoose, { Document, Schema } from 'mongoose';
 
+/**
+ * Shape of a lock document. Exported for documentation and for tests that
+ * deliberately inspect raw lock state; the model itself is *not* exported
+ * (see the note on `CabinBookingLock` below).
+ */
 export interface ICabinBookingLock extends Document {
   cabin: mongoose.Types.ObjectId;
   token: string;
@@ -35,8 +40,75 @@ const CabinBookingLockSchema: Schema = new Schema(
 // comes, mirroring the ProcessedStripeEvent TTL pattern.
 CabinBookingLockSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-const CabinBookingLock =
+// Module-private on purpose. This is the one Mongoose model in the repo
+// that must never be reachable as raw CRUD: a stray `.create()`,
+// `.deleteOne()`, or `.findOneAndUpdate()` from a route or script would
+// silently corrupt the mutex (delete another holder's live lock, or
+// insert a document whose `expiresAt` math doesn't match the TTL the
+// acquire loop assumes). Everything callers may legitimately do is
+// expressed by the two methods exported below, so the raw model is
+// unreachable outside this module at the type level rather than by
+// convention (issue #126).
+const CabinBookingLockModel =
   mongoose.models.CabinBookingLock ||
   mongoose.model<ICabinBookingLock>('CabinBookingLock', CabinBookingLockSchema);
+
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: number }).code === 11000
+  );
+}
+
+/**
+ * The per-cabin booking mutex's storage protocol: the two atomic
+ * primitives that back `withCabinBookingLock()` (`lib/cabin-booking-lock.ts`).
+ * The retry loop, TTL budget, and timeout semantics live there; this
+ * module owns only the fencing-token contract and the document shape.
+ */
+const CabinBookingLock = {
+  /**
+   * Atomically take the lock for `cabin`, stamping it with `token` and an
+   * expiry `ttlMs` in the future. Resolves `true` when the lock is held by
+   * this caller — either because no document existed or because the
+   * existing one had already expired and was reclaimed in place.
+   *
+   * Resolves `false` when a live (non-expired) holder already owns the
+   * lock: the filter matches nothing, so Mongo attempts an upsert *insert*
+   * instead, which collides with the unique index on `cabin` and throws
+   * E11000. That collision is the contention signal, not an error — every
+   * other failure is rethrown.
+   */
+  async acquire(
+    cabin: mongoose.Types.ObjectId,
+    token: string,
+    ttlMs: number
+  ): Promise<boolean> {
+    const now = new Date();
+    try {
+      await CabinBookingLockModel.findOneAndUpdate(
+        { cabin, expiresAt: { $lt: now } },
+        { $set: { token, expiresAt: new Date(now.getTime() + ttlMs) } },
+        { upsert: true, runValidators: true }
+      );
+      return true;
+    } catch (error) {
+      if (isDuplicateKeyError(error)) return false;
+      throw error;
+    }
+  },
+
+  /**
+   * Release `cabin`'s lock, but only if `token` still matches — the
+   * fencing token. A holder that overran its TTL and was reclaimed by
+   * another request no longer matches, so its late release deletes
+   * nothing instead of freeing the new holder's lock.
+   */
+  async release(cabin: mongoose.Types.ObjectId, token: string): Promise<void> {
+    await CabinBookingLockModel.deleteOne({ cabin, token });
+  },
+};
 
 export default CabinBookingLock;

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,9 +1,10 @@
 // Export all models
+// `CabinBookingLock` is deliberately absent: it is infrastructure for the
+// per-cabin booking mutex, not a domain model, and re-exporting it here
+// would put raw lock CRUD one autocomplete away from every route that
+// imports from this barrel. Use `withCabinBookingLock()` from
+// `@/lib/cabin-booking-lock` instead (issue #126).
 export { default as Booking, type IBooking } from './Booking';
-export {
-  default as CabinBookingLock,
-  type ICabinBookingLock,
-} from './CabinBookingLock';
 export { default as Cabin, type ICabin } from './Cabin';
 export { default as Dining, type IDining } from './Dining';
 export { Experience, type IExperience } from './Experience';


### PR DESCRIPTION
Closes #126.

## Summary
- Makes the `CabinBookingLock` Mongoose model module-private in `models/CabinBookingLock.ts` and exports only two protocol methods — `acquire(cabin, token, ttlMs)` and `release(cabin, token)` — so raw `.create()` / `.deleteOne()` / `.findOneAndUpdate()` on the lock collection is unreachable at the type level from outside that module.
- Drops `CabinBookingLock` and `ICabinBookingLock` from the `models/index.ts` barrel; the lock is mutex infrastructure, not a domain model, and the barrel is what every route imports from.
- Moves the atomic acquire (upsert-with-expiry filter) and the fencing-token release out of `withCabinBookingLock()` and into those methods; `lib/cabin-booking-lock.ts` keeps the retry budget, `LOCK_TTL_MS`, and `CabinBookingLockTimeoutError`.
- `acquire()` translates E11000 into a `false` return — contention is a signal, not an error — and rethrows everything else. Previously that translation was inline in the retry loop's `catch`.
- Adds a `CabinBookingLock protocol` suite covering acquire-when-free, refuse-when-held, reclaim-when-expired, release-when-held, the fencing-token case (a reclaimed holder's late release must not free its successor's lock), and non-contention errors rethrown.
- Updates `CLAUDE.md`'s `### Booking Validation` section: the "must go through the same lock" rule is now stated as structurally enforced, with a note not to add a raw-model export or barrel entry to work around it.

## Why
Issue #126 offered three approaches; this is the "combination" bullet, minus a lint rule. With the model private and the barrel entry gone there is nothing left to restrict via `no-restricted-imports` — TypeScript is the enforcement, so a lint rule would be redundant surface.

`withCabinBookingLock()` is unchanged from its callers' perspective (`app/api/bookings/route.ts` POST/PUT are untouched). The guarantee is scoped honestly in the function's doc comment: the worst a caller reaching past the wrapper can now do is hold a *well-formed* lock until its TTL expires, rather than delete a live holder's lock or write a bogus `expiresAt`.

## Notes
Existing assertions in `__tests__/integration/lib/cabin-booking-lock.test.ts` are unmodified, per the issue's acceptance criteria. Two setup-only changes were required:
- The two spies retarget from the raw model to the protocol methods: `deleteOne` → `release`, and `findOneAndUpdate` (rejecting E11000) → `acquire` (resolving `false`).
- Tests that plant or inspect raw lock documents now reach the model via `mongoose.model('CabinBookingLock')`, a deliberate and commented escape hatch that production code has no reason to reproduce.

Real E11000 handling is still exercised end-to-end by the pre-existing `lets only one of two concurrent reclaimers win the same stale lock` test and by the new `refuses to acquire a lock a live holder still owns`.

## Test plan
- [x] `pnpm ci:check` — format clean, lint 0 errors, `54 suites / 959 tests` passing
- [x] `pnpm check:types` — clean, no TypeScript errors
- [x] `pnpm test:integration -- cabin-booking-lock` — 18/18 pass (11 pre-existing + 7 new)
